### PR TITLE
fix: restore order search and filter count functionality

### DIFF
--- a/RestroHub-FrontEnd/src/components/admin/orders/Orders.jsx
+++ b/RestroHub-FrontEnd/src/components/admin/orders/Orders.jsx
@@ -7,6 +7,7 @@ import OrdersGrid from './orderComponents/OrdersGrid';
 const Orders = () => {
   const [activeFilter, setActiveFilter] = useState('all');
   const [searchQuery, setSearchQuery] = useState('');
+  const [orders, setOrders] = useState([]);
 
   const filters = [
     { id: 'all', label: 'All' },
@@ -18,27 +19,21 @@ const Orders = () => {
 
   return (
     <div className="space-y-6">
-      {/* Header + Search */}
       <OrdersHeader
         searchQuery={searchQuery}
         onSearchChange={setSearchQuery}
       />
-
-      {/* Filter Tabs */}
       <OrderFilters
         filters={filters}
         activeFilter={activeFilter}
         onFilterChange={setActiveFilter}
-        orders={[]}  // Will be managed inside OrdersGrid
+        orders={orders}
       />
-
-      {/* Status Legend */}
       <StatusLegend />
-
-      {/* Orders Grid */}
       <OrdersGrid
         activeFilter={activeFilter}
         searchQuery={searchQuery}
+        onOrdersChange={setOrders}
       />
     </div>
   );

--- a/RestroHub-FrontEnd/src/components/admin/orders/orderComponents/OrdersGrid.jsx
+++ b/RestroHub-FrontEnd/src/components/admin/orders/orderComponents/OrdersGrid.jsx
@@ -48,11 +48,17 @@ const OrderCardSkeleton = () => (
 // ============================================
 // MAIN COMPONENT
 // ============================================
-const OrdersGrid = ({ activeFilter, searchQuery }) => {
+const OrdersGrid = ({ activeFilter, searchQuery, onOrdersChange }) => {
   const [orders, setOrders] = useState([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState(null);
   const [refreshing, setRefreshing] = useState(false);
+
+  // Sync orders up to parent so OrderFilters gets real counts
+  const syncOrders = (updated) => {
+    setOrders(updated);
+    onOrdersChange?.(updated);
+  };
 
   // ------------------------------------
   // FALLBACK DATA
@@ -128,11 +134,11 @@ const OrdersGrid = ({ activeFilter, searchQuery }) => {
 
       // 🎭 MOCK
       await new Promise((resolve) => setTimeout(resolve, 700));
-      setOrders(fallbackOrders);
+      syncOrders(fallbackOrders);
     } catch (err) {
       console.error('Failed to fetch orders:', err);
       setError('Failed to load orders');
-      setOrders(fallbackOrders);
+      syncOrders(fallbackOrders);
     } finally {
       setLoading(false);
       setRefreshing(false);
@@ -144,26 +150,27 @@ const OrdersGrid = ({ activeFilter, searchQuery }) => {
   // ------------------------------------
   const handleStatusUpdate = (orderId, newStatus) => {
     if (newStatus === 'complete') {
-      setOrders((prev) => prev.filter((o) => o.id !== orderId));
+      syncOrders(orders.filter((o) => o.id !== orderId));
     } else {
-      setOrders((prev) =>
-        prev.map((o) => (o.id === orderId ? { ...o, status: newStatus } : o))
-      );
+      syncOrders(orders.map((o) => (o.id === orderId ? { ...o, status: newStatus } : o)));
     }
   };
 
-  // ------------------------------------
-  // FILTER + SEARCH
-  // ------------------------------------
+  const query = searchQuery.trim().toLowerCase();
+
   const filteredOrders = orders
     .filter((o) => activeFilter === 'all' || o.status === activeFilter)
-    .filter(
-      (o) =>
-        !searchQuery ||
-        o.id.toString().includes(searchQuery) ||
-        o.customer.toLowerCase().includes(searchQuery.toLowerCase()) ||
-        o.table.toString().includes(searchQuery)
-    );
+    .filter((o) => {
+      if (!query) return true;
+      return (
+        o.id.toString().includes(query) ||
+        o.customer.toLowerCase().includes(query) ||
+        o.table.toString().includes(query) ||
+        o.status.toLowerCase().includes(query) ||
+        o.phone.includes(query) ||
+        o.items.some((item) => item.name.toLowerCase().includes(query))
+      );
+    });
 
   // ------------------------------------
   // RENDER

--- a/RestroHub-FrontEnd/src/components/admin/orders/orderComponents/OrdersHeader.jsx
+++ b/RestroHub-FrontEnd/src/components/admin/orders/orderComponents/OrdersHeader.jsx
@@ -16,7 +16,7 @@ const OrdersHeader = ({ searchQuery, onSearchChange }) => {
           type="text"
           value={searchQuery}
           onChange={(e) => onSearchChange(e.target.value)}
-          placeholder="Search by order ID, customer..."
+          placeholder="Search by order ID, customer, table, status or item..."
           className="bg-transparent outline-none flex-1 text-sm text-gray-800 placeholder-gray-400"
         />
         {searchQuery && (


### PR DESCRIPTION
- Lift orders state to Orders.jsx so OrderFilters receives real data
- Add onOrdersChange callback so OrdersGrid syncs mutations to parent
- Expand search to match status, phone, and item names
- Update search placeholder to reflect all searchable fields

Fixes #46