### PR TITLE
Fix: Prevent NullPointerException in updateFood imageUrl comparison 

### DIFF
--- a/RestroHub/src/main/java/com/restroly/qrmenu/food/service/FoodServiceImpl.java
+++ b/RestroHub/src/main/java/com/restroly/qrmenu/food/service/FoodServiceImpl.java
@@ -170,7 +170,7 @@ public class FoodServiceImpl implements FoodService {
         }
 
         // Safe null check for imageUrl
-        if(Objects.equals(updateDTO.getImageUrl(), existingFood.getImageUrl())) {
+        if(!Objects.equals(updateDTO.getImageUrl(), existingFood.getImageUrl())) {
             String imageUrl = null;
             if (image != null && !image.isEmpty()) {
                 imageUrl = cloudinaryService.uploadImage(image, "qrmenu/foods");
@@ -181,7 +181,7 @@ public class FoodServiceImpl implements FoodService {
         }
 
         // Safe null check for categoryId
-        if(Objects.equals(existingFood.getCategory().getCategoryId(), updateDTO.getCategoryId())) {
+        if(!Objects.equals(existingFood.getCategory().getCategoryId(), updateDTO.getCategoryId())) {
             if (updateDTO.getCategoryId() != null) {
                 Category category = categoryRepository.findById(updateDTO.getCategoryId())
                         .orElseThrow(() -> new ResourceNotFoundException("Category not found with id: " + updateDTO.getCategoryId()));

--- a/RestroHub/src/main/java/com/restroly/qrmenu/food/service/FoodServiceImpl.java
+++ b/RestroHub/src/main/java/com/restroly/qrmenu/food/service/FoodServiceImpl.java
@@ -31,6 +31,7 @@ import java.math.BigDecimal;
 import java.util.List;
 import java.lang.Long;
 import java.util.Map;
+import java.util.Objects;
 
 @Service
 @RequiredArgsConstructor
@@ -167,7 +168,9 @@ public class FoodServiceImpl implements FoodService {
             throw new ResourceAlreadyExistsException(
                     String.format(FOOD_EXISTS_MSG, updateDTO.getName()));
         }
-        if(!updateDTO.getImageUrl().equals(existingFood.getImageUrl())){
+
+        // Safe null check for imageUrl
+        if(Objects.equals(updateDTO.getImageUrl(), existingFood.getImageUrl())) {
             String imageUrl = null;
             if (image != null && !image.isEmpty()) {
                 imageUrl = cloudinaryService.uploadImage(image, "qrmenu/foods");
@@ -176,13 +179,16 @@ public class FoodServiceImpl implements FoodService {
                 updateDTO.setImageUrl(imageUrl);
             }
         }
-        if(existingFood.getCategory().getCategoryId() != updateDTO.getCategoryId()){
+
+        // Safe null check for categoryId
+        if(Objects.equals(existingFood.getCategory().getCategoryId(), updateDTO.getCategoryId())) {
             if (updateDTO.getCategoryId() != null) {
                 Category category = categoryRepository.findById(updateDTO.getCategoryId())
                         .orElseThrow(() -> new ResourceNotFoundException("Category not found with id: " + updateDTO.getCategoryId()));
                 existingFood.setCategory(category);
             }
         }
+        
         foodMapper.updateEntityFromDTO(updateDTO, existingFood);
         Food updatedFood = foodRepository.save(existingFood);
 


### PR DESCRIPTION
Fixes #136 

### Changes Made
- Replaced `.equals()` with `Objects.equals()` for imageUrl comparison in `updateFood` to prevent NullPointerException.
- Updated `categoryId` comparison to use `Objects.equals()` instead of `!=` for safe Long value comparison.

### Notes
The categoryId fix was an additional improvement I noticed while working on the assigned issue. Please confirm if it’s okay to keep this in the same PR or if you’d prefer a separate one.
