### PR TITLE
fix(frontend): wrap app with GoogleOAuthProvider to fix login crash

### DIFF
--- a/ReadMe.md
+++ b/ReadMe.md
@@ -233,7 +233,12 @@ Create a `.env` file in `RestroHub-FrontEnd/` (see `.env.example`):
 ```env
 # Base URL for the Spring context path (no trailing slash). Vite only reads VITE_* variables.
 VITE_API_BASE_URL=http://localhost:8181/restroly
+
+# Google Sign-In (OAuth 2.0 Web client ID) — required for /login
+VITE_GOOGLE_CLIENT_ID=your_google_oauth_client_id_here
 ```
+
+Create OAuth credentials in [Google Cloud Console](https://console.cloud.google.com/apis/credentials) (OAuth 2.0 Client ID, type **Web application**). Add `http://localhost:5173` (or your Vite dev URL) to authorized JavaScript origins.
 
 Optional:
 

--- a/RestroHub-FrontEnd/.env.example
+++ b/RestroHub-FrontEnd/.env.example
@@ -2,3 +2,6 @@
 # Vite only exposes variables prefixed with VITE_.
 
 VITE_API_BASE_URL=http://localhost:8181/restroly
+
+# Google OAuth (required for Login page — create credentials in Google Cloud Console)
+VITE_GOOGLE_CLIENT_ID=your_google_oauth_client_id_here

--- a/RestroHub-FrontEnd/src/main.jsx
+++ b/RestroHub-FrontEnd/src/main.jsx
@@ -1,16 +1,16 @@
-// src/main.jsx
-import React from 'react';
-import ReactDOM from 'react-dom/client';
-import App from './App';
-import './index.css';
+import React from "react";
+import ReactDOM from "react-dom/client";
 import { GoogleOAuthProvider } from "@react-oauth/google";
-<GoogleOAuthProvider clientId="YOUR_GOOGLE_CLIENT_ID"> 
-  <App /> 
-</GoogleOAuthProvider>
 
-ReactDOM.createRoot(document.getElementById('root')).render(
+import App from "./App";
+import "./index.css";
+
+const googleClientId = import.meta.env.VITE_GOOGLE_CLIENT_ID ?? "";
+
+ReactDOM.createRoot(document.getElementById("root")).render(
   <React.StrictMode>
-    <GoogleOAuthProvider clientId={import.meta.env.VITE_GOOGLE_CLIENT_ID} > 
-      <App /> 
-      </GoogleOAuthProvider> 
-      </React.StrictMode> );
+    <GoogleOAuthProvider clientId={googleClientId}>
+      <App />
+    </GoogleOAuthProvider>
+  </React.StrictMode>
+);


### PR DESCRIPTION
## Summary
Fixes #139

- Repair `RestroHub-FrontEnd/src/main.jsx` (removed invalid top-level JSX and duplicate providers)
- Wrap `<App />` in `<GoogleOAuthProvider clientId={import.meta.env.VITE_GOOGLE_CLIENT_ID}>`
- Document `VITE_GOOGLE_CLIENT_ID` in `.env.example` and README Frontend Setup

## Test plan
- [ ] `cd RestroHub-FrontEnd && cp .env.example .env` and set a valid Google client ID
- [ ] `npm install && npm run dev`
- [ ] Open `/login` — page renders (no white screen); Google button visible