### PR TITLE
fix(food): null-safe imageUrl in updateFood (#136)

### DIFF
--- a/RestroHub/src/main/java/com/restroly/qrmenu/food/service/FoodServiceImpl.java
+++ b/RestroHub/src/main/java/com/restroly/qrmenu/food/service/FoodServiceImpl.java
@@ -167,7 +167,7 @@ public class FoodServiceImpl implements FoodService {
             throw new ResourceAlreadyExistsException(
                     String.format(FOOD_EXISTS_MSG, updateDTO.getName()));
         }
-        if(!updateDTO.getImageUrl().equals(existingFood.getImageUrl())){
+        if (!java.util.Objects.equals(updateDTO.getImageUrl(), existingFood.getImageUrl())) {
             String imageUrl = null;
             if (image != null && !image.isEmpty()) {
                 imageUrl = cloudinaryService.uploadImage(image, "qrmenu/foods");


### PR DESCRIPTION
## Summary
- Use `Objects.equals` when comparing `updateDTO.getImageUrl()` and `existingFood.getImageUrl()` to avoid NPE when imageUrl is null.

Fixes #136

## Test plan
- [ ] Update food without imageUrl in DTO does not throw NPE