### PR TITLE
fix(menu): duplicate name check on restore (#149)

### DIFF
--- a/RestroHub/src/main/java/com/restroly/qrmenu/menu/service/MenuServiceImpl.java
+++ b/RestroHub/src/main/java/com/restroly/qrmenu/menu/service/MenuServiceImpl.java
@@ -201,6 +201,14 @@ public class MenuServiceImpl implements MenuService {
             return menuMapper.toResponseDTO(menu);
         }
 
+        if (menu.getBranch() != null
+                && menuRepository.existsByMenuNameAndBranch_BranchId(
+                        menu.getMenuName(), menu.getBranch().getBranchId())) {
+            throw new DuplicateResourceException(
+                    "Menu with name '" + menu.getMenuName()
+                            + "' already exists for this branch");
+        }
+
         menu.setDeleted(false);
         Menu restoredMenu = menuRepository.save(menu);
 


### PR DESCRIPTION
## Summary
- Before restoring a soft-deleted menu, verify no active menu with the same name exists in the branch (409 via DuplicateResourceException).

Fixes #149

## Test plan
- [ ] Restore succeeds when name is unique
- [ ] Restore fails with conflict when duplicate active name exists