### PR TITLE
fix(validation): add category duplicate check and restaurant‑scoped food validation

### DIFF
--- a/RestroHub/src/main/java/com/restroly/qrmenu/category/repository/CategoryRepository.java
+++ b/RestroHub/src/main/java/com/restroly/qrmenu/category/repository/CategoryRepository.java
@@ -11,4 +11,7 @@ import com.restroly.qrmenu.category.entity.Category;
 public interface CategoryRepository extends JpaRepository<Category, Long> {
 
 	List<Category> findByMenu_MenuId(long menuId);
+
+	//New method for duplicate validation
+    boolean existsByNameAndRestaurantId(String name, Long restaurantId)
 }

--- a/RestroHub/src/main/java/com/restroly/qrmenu/category/service/CategoryServiceImpl.java
+++ b/RestroHub/src/main/java/com/restroly/qrmenu/category/service/CategoryServiceImpl.java
@@ -27,6 +27,13 @@ public class CategoryServiceImpl implements CategoryService {
 	@Transactional
 	public CategoryResponseDTO createCategory(CategoryRequestDTO requestDTO) {
 
+		//Duplicate check
+		if (categoryRepository.existsByNameAndRestaurantId(
+			requestDTO.getName(), requestDTO.getRestaurantId())) {
+				throw new DuplicateResourceException("Category with name '" + requestDTO.getName() + "' already exists for this restaurant.");
+			
+		}
+    
 		Category category = CategoryDTO.toEntity(
 				CategoryDTO.builder()
 						.name(requestDTO.getName())

--- a/RestroHub/src/main/java/com/restroly/qrmenu/food/service/FoodService.java
+++ b/RestroHub/src/main/java/com/restroly/qrmenu/food/service/FoodService.java
@@ -47,4 +47,8 @@ public interface FoodService {
     boolean existsById(Long id);
 
     boolean existsByName(String name);
+
+    // New method to check if a food with the same name exists for the same restaurant
+    boolean existsByNameAndRestaurantIdIgnoreCase(String name, Long restaurantId);
+
 }

--- a/RestroHub/src/main/java/com/restroly/qrmenu/food/service/FoodServiceImpl.java
+++ b/RestroHub/src/main/java/com/restroly/qrmenu/food/service/FoodServiceImpl.java
@@ -52,8 +52,17 @@ public class FoodServiceImpl implements FoodService {
     @CacheEvict(value = "foods", allEntries = true)
     public FoodResponseDTO createFood(FoodRequestDTO requestDTO, MultipartFile image) {
 
-        if (foodRepository.existsByNameIgnoreCase(requestDTO.getName())) {
-            throw new ResourceAlreadyExistsException("Food already exists: " + requestDTO.getName());
+        //This is validating globally not per restaurant, so we will remove this validation
+        // if (foodRepository.existsByNameIgnoreCase(requestDTO.getName())) {
+        //     throw new ResourceAlreadyExistsException("Food already exists: " + requestDTO.getName());
+        // } 
+
+        // New validation to check if a food with the same name exists for the same restaurant
+        if(foodRepository.existsByNameAndRestaurantIdIgnoreCase(requestDTO.getName(), requestDTO.getRestaurantId())) {
+            log.warn("Attempt to create duplicate food with name: {} for restaurant id: {}",
+                    requestDTO.getName(), requestDTO.getRestaurantId());
+            throw new ResourceAlreadyExistsException(
+                "Food with name '" + requestDTO.getName() +"' already exists for this restaurant");
         }
 
         String imageUrl = null;


### PR DESCRIPTION
This PR adds new validation logic to strengthen data integrity in specific modules.  
Other modules (Menu, Order, Restaurant, User) already had validation checks implemented — this PR focuses only on the missing pieces. #156  

###  Changes
- **Category**: Added duplicate name validation on create.  
- **Food**: Replaced global duplicate check with restaurant‑scoped validation.

###  Notes
I have only added these two validations because the rest of the modules already had proper validation logic in place.  
If any additional validation is expected or has been missed, please highlight it so I can address it in a follow‑up.
