### PR TITLE
Fix: Add custom exceptions for inactive and locked users in CustomUserDetailsService

### DIFF
--- a/RestroHub/src/main/java/com/restroly/qrmenu/security/CustomUserDetailsService.java
+++ b/RestroHub/src/main/java/com/restroly/qrmenu/security/CustomUserDetailsService.java
@@ -8,6 +8,9 @@ import org.springframework.security.core.userdetails.UserDetailsService;
 import org.springframework.security.core.userdetails.UsernameNotFoundException;
 import org.springframework.stereotype.Service;
 
+import com.restroly.qrmenu.security.exception.UserDisabledException;
+import com.restroly.qrmenu.security.exception.UserLockedException;
+
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -28,11 +31,19 @@ public class CustomUserDetailsService implements UserDetailsService {
                     log.warn("User not found with email: {}", email);
                     return new UsernameNotFoundException("User not found with email: " + email);
                 });
-
+        // Check if the user account is active
         if (!user.isActive()) {
             log.warn("User account is inactive: {}", email);
-            throw new UsernameNotFoundException("User account is inactive: " + email);
+            throw new UserDisabledException("User account is inactive: " + email);
         }
+
+        // Check if the user account is locked
+        if (user.isLocked()) {
+            log.warn("User account is locked: {}", email);
+            throw new UserLockedException("User account is locked: " + email);
+        }
+
+
 
         List<SimpleGrantedAuthority> authorities = user.getRoles().stream()
                 .map(role -> new SimpleGrantedAuthority(role.getName()))

--- a/RestroHub/src/main/java/com/restroly/qrmenu/security/CustomUserDetailsService.java
+++ b/RestroHub/src/main/java/com/restroly/qrmenu/security/CustomUserDetailsService.java
@@ -34,16 +34,14 @@ public class CustomUserDetailsService implements UserDetailsService {
         // Check if the user account is active
         if (!user.isActive()) {
             log.warn("User account is inactive: {}", email);
-            throw new UserDisabledException("User account is inactive: " + email);
+            throw new UserDisabledException("User account is inactive");
         }
 
         // Check if the user account is locked
         if (user.isLocked()) {
             log.warn("User account is locked: {}", email);
-            throw new UserLockedException("User account is locked: " + email);
+            throw new UserLockedException("User account is locked");
         }
-
-
 
         List<SimpleGrantedAuthority> authorities = user.getRoles().stream()
                 .map(role -> new SimpleGrantedAuthority(role.getName()))

--- a/RestroHub/src/main/java/com/restroly/qrmenu/security/exception/UserDisabledException.java
+++ b/RestroHub/src/main/java/com/restroly/qrmenu/security/exception/UserDisabledException.java
@@ -1,8 +1,8 @@
 package com.restroly.qrmenu.security.exception;
 
-import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.authentication.DisabledException;
 
-public class UserDisabledException extends AuthenticationException {
+public class UserDisabledException extends DisabledException {
     public UserDisabledException(String msg) {
         super(msg);
     }

--- a/RestroHub/src/main/java/com/restroly/qrmenu/security/exception/UserDisabledException.java
+++ b/RestroHub/src/main/java/com/restroly/qrmenu/security/exception/UserDisabledException.java
@@ -1,0 +1,9 @@
+package com.restroly.qrmenu.security.exception;
+
+import org.springframework.security.core.AuthenticationException;
+
+public class UserDisabledException extends AuthenticationException {
+    public UserDisabledException(String msg) {
+        super(msg);
+    }
+}

--- a/RestroHub/src/main/java/com/restroly/qrmenu/security/exception/UserLockedException.java
+++ b/RestroHub/src/main/java/com/restroly/qrmenu/security/exception/UserLockedException.java
@@ -1,8 +1,8 @@
 package com.restroly.qrmenu.security.exception;
 
-import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.authentication.LockedException;
 
-public class UserLockedException extends AuthenticationException {
+public class UserLockedException extends LockedException {
     public UserLockedException(String msg) {
         super(msg);
     }

--- a/RestroHub/src/main/java/com/restroly/qrmenu/security/exception/UserLockedException.java
+++ b/RestroHub/src/main/java/com/restroly/qrmenu/security/exception/UserLockedException.java
@@ -1,0 +1,9 @@
+package com.restroly.qrmenu.security.exception;
+
+import org.springframework.security.core.AuthenticationException;
+
+public class UserLockedException extends AuthenticationException {
+    public UserLockedException(String msg) {
+        super(msg);
+    }
+}


### PR DESCRIPTION
### Description
This PR introduces two custom exceptions (`UserDisabledException` and `UserLockedException`) and updates `CustomUserDetailsService` to throw them when appropriate.

- Inactive users → `UserDisabledException`
- Locked users → `UserLockedException`
- Non-existent users → `UsernameNotFoundException`
- Logging remains unchanged for clarity and debugging.
- The existing logic for user retrieval and role assignment is preserved.

These changes are implemented as per @rdodiya's feedback.


### Related Issue
Closes #166 

### Changes Made
- Added `UserDisabledException` and `UserLockedException` classes under `com.restroly.qrmenu.security.exception`.
- Updated `CustomUserDetailsService` to throw these exceptions based on `isActive` and `isLocked` flags.
- Preserved existing logging and logic.