### PR TITLE
 feat(frontend): strengthen login password validation

### DIFF
--- a/RestroHub-FrontEnd/src/pages/public/Login.jsx
+++ b/RestroHub-FrontEnd/src/pages/public/Login.jsx
@@ -14,10 +14,13 @@ const API_BASE_URL =
   import.meta.env.VITE_API_BASE_URL || "http://localhost:8181/restroly";
 
 const validationSchema = Yup.object({
-    username: Yup.string().required("Email or username is required"),
+  username: Yup.string().required("Email or username is required"),
   password: Yup.string()
-    .min(6, "Password must be at least 6 characters")
-    .required("Password is required"),
+    .required("Password is required")
+    .matches(
+      /^(?=.*[a-z])(?=.*[A-Z])(?=.*\d)(?=.*[!@#$%^&*()_+\-=[\]{};':"\\|,.<>\/?`~]).{8,}$/,
+      "Password must be at least 8 characters and include uppercase, lowercase, number, and special character"
+    ),
 });
 
 /* ──────────────────── SVG Icons (inlined) ──────────────────── */
@@ -338,7 +341,7 @@ const handleGoogleLogin = async (credentialResponse) => {
                       name="password"
                       type={showPassword ? "text" : "password"}
                       autoComplete="new-password"
-                      placeholder="6+ Characters, 1 Capital letter"
+                      placeholder="Minimum 8 characters; include uppercase, lowercase, number, special character"
                       disabled={isLoading}
                       value={formik.values.password}
                       onChange={formik.handleChange}


### PR DESCRIPTION
Summary:
 
Enhances  the issue  [38](https://github.com/rdodiya/RestroHub/issues/38) .
Enhance password rules on the login page to require minimum 8 characters, at least one uppercase letter, one lowercase letter, one number, and one special character. Update validation message and input placeholder.

Changes Made:

- Validation: Replaced the previous Yup password rule with a regex enforcing:

- Minimum 8 characters
- At least 1 uppercase letter
- At least 1 lowercase letter
- At least 1 number
- At least 1 special character

- UI: Updated the password input placeholder to: "Minimum 8 characters; include uppercase, lowercase, number, special character" .
 
Local verification: 
Ran frontend dev server and validated form behavior on localhost (http://localhost:3000). Confirmed invalid passwords are rejected by client validation and valid passwords submit to the backend. No backend code changes required.
