### PR TITLE
fix(auth): add back navigation and register route integration

### DIFF
--- a/RestroHub-FrontEnd/src/pages/public/Login.jsx
+++ b/RestroHub-FrontEnd/src/pages/public/Login.jsx
@@ -7,6 +7,7 @@ import * as Yup from "yup";
 import axios from "axios";
 import toast from "react-hot-toast";
 import { GoogleLogin } from "@react-oauth/google";
+import { ArrowLeft } from "lucide-react";
 import api from "@services/common/api";
 import { useTheme } from "@context/ThemeContext";
 
@@ -285,6 +286,16 @@ const handleGoogleLogin = async (credentialResponse) => {
                   🍽️ Restroly
                 </span>
               </div>
+
+            <Link 
+              to="/"
+              className="mb-4 inline-flex items-center text-sm text-gray-400 transition-colors hover:text-gray-300 gap-2"
+              >
+                <ArrowLeft size={15}/>
+                  Back to Home 
+              </Link>
+
+              
 
               <p className="mb-1 text-sm font-medium text-gray-500 dark:text-gray-400">
                 Welcome back!

--- a/RestroHub-FrontEnd/src/pages/public/Register.jsx
+++ b/RestroHub-FrontEnd/src/pages/public/Register.jsx
@@ -6,6 +6,7 @@ import { useFormik } from "formik";
 import * as Yup from "yup";
 import toast from "react-hot-toast";
 import api from "@services/common/api";
+import { ArrowLeft } from "lucide-react";
 
 /* ──────────────────── SVG Icons ──────────────────── */
 
@@ -138,6 +139,13 @@ const Register = () => {
               <div className="mb-8 flex items-center justify-center xl:hidden">
                 <span className="text-2xl font-bold text-blue-600">🍽️ Restroly</span>
               </div>
+              <Link
+                to="/"
+                className="mb-4 inline-flex items-center text-sm text-gray-400 transition-colors hover:text-gray-300 gap-2"
+              >
+                <ArrowLeft size={15} />
+                Back to Home
+              </Link>
               <h2 className="mb-8 text-2xl font-bold text-gray-900 dark:text-white sm:text-3xl">Create Account</h2>
 
               <form onSubmit={formik.handleSubmit} noValidate>


### PR DESCRIPTION
## Issue Link

Closes #86

---

## Changes Made

- Added a **"Back to Home"** navigation button to the Login page
- Added a **"Back to Home"** navigation button to the Register page
- Implemented missing Register page integration
- Added `/register` route configuration
- Ensured responsive styling for authentication page navigation

---

## Type of Change

- [x] New feature
- [x] Bug fix
- [ ] Documentation update
- [ ] Code refactor

---

## Testing Performed

### Frontend Testing

- [x] Component renders correctly
- [x] Responsive on mobile/tablet/desktop
- [x] No console runtime errors

### Test Cases

- Verified Login page renders correctly
- Verified Register page renders correctly through `/register`
- Verified "Back to Home" navigation redirects properly
- Verified responsive layout behavior manually

---

## UI/UX Changes

### Before

- Users could not navigate back to the homepage from authentication pages without using browser navigation controls
- `/register` route existed but Register page integration was incomplete

### After

- Added in-app **"Back to Home"** navigation on Login and Register pages
- Added functional Register page integration with proper routing

---

## Additional Notes

- Verified locally using:

```bash
npm run dev
Changes were intentionally kept scoped to:
Authentication page navigation enhancement
Register route integration
```
## Screenshots: 
**Login:**
<img width="1918" height="1071" alt="Login Route" src="https://github.com/user-attachments/assets/d52fa42a-fc22-4fe5-aac1-f03cd99218dc" />


**Register:**
<img width="1917" height="1078" alt="Register Route" src="https://github.com/user-attachments/assets/aaa65f23-33a7-4e33-b8e8-7d6a740921b3" />


