### PR TITLE
feat: add active categories endpoint

### DIFF
--- a/RestroHub/src/main/java/com/restroly/qrmenu/category/controller/CategoryController.java
+++ b/RestroHub/src/main/java/com/restroly/qrmenu/category/controller/CategoryController.java
@@ -16,8 +16,6 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
-import com.restroly.qrmenu.category.dto.CategoryDTO;
-import com.restroly.qrmenu.category.service.CategoryService;
 
 @RestController
 @RequestMapping("/secure/api/v1/categories")
@@ -59,5 +57,13 @@ public class CategoryController {
 	public ResponseEntity<ApiResponse<Void>> deleteCategory(@PathVariable Long id) {
 		categoryService.deleteCategory(id);
 		return ResponseEntity.ok(ApiResponse.success(null, "Category deleted (soft-deleted) successfully"));
+	}
+
+	@GetMapping("/activecategories")
+	public ResponseEntity<ApiResponse<PagedResponse<CategoryResponseDTO>>> getActiveCategories(
+			@PageableDefault(page = 0, size = 10, sort = "name") Pageable pageable) {
+		Page<CategoryResponseDTO> categoryPage = categoryService.getActiveCategories(pageable);
+		PagedResponse<CategoryResponseDTO> pagedResponse = PagedResponse.from(categoryPage);
+		return ResponseEntity.ok(ApiResponse.success(pagedResponse, "Active categories retrieved successfully"));
 	}
 }

--- a/RestroHub/src/main/java/com/restroly/qrmenu/category/repository/CategoryRepository.java
+++ b/RestroHub/src/main/java/com/restroly/qrmenu/category/repository/CategoryRepository.java
@@ -2,6 +2,8 @@ package com.restroly.qrmenu.category.repository;
 
 import java.util.List;
 
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
@@ -11,4 +13,7 @@ import com.restroly.qrmenu.category.entity.Category;
 public interface CategoryRepository extends JpaRepository<Category, Long> {
 
 	List<Category> findByMenu_MenuId(long menuId);
+
+	Page<Category> findByIsDeleteFalse(Pageable pageable);
+
 }

--- a/RestroHub/src/main/java/com/restroly/qrmenu/category/service/CategoryService.java
+++ b/RestroHub/src/main/java/com/restroly/qrmenu/category/service/CategoryService.java
@@ -18,6 +18,6 @@ public interface CategoryService {
 
 	public void deleteCategory(Long id);
 
-	Page<CategoryResponseDTO> getActiveCategories(Pageable pageable);
+	public Page<CategoryResponseDTO> getActiveCategories(Pageable pageable);
 
 }

--- a/RestroHub/src/main/java/com/restroly/qrmenu/category/service/CategoryService.java
+++ b/RestroHub/src/main/java/com/restroly/qrmenu/category/service/CategoryService.java
@@ -17,4 +17,7 @@ public interface CategoryService {
 	public CategoryResponseDTO updateCategory(Long id, CategoryRequestDTO requestDTO);
 
 	public void deleteCategory(Long id);
+
+	Page<CategoryResponseDTO> getActiveCategories(Pageable pageable);
+
 }

--- a/RestroHub/src/main/java/com/restroly/qrmenu/category/service/CategoryServiceImpl.java
+++ b/RestroHub/src/main/java/com/restroly/qrmenu/category/service/CategoryServiceImpl.java
@@ -109,4 +109,12 @@ public class CategoryServiceImpl implements CategoryService {
 		log.info("Category with ID: {} marked as deleted", id);
 		categoryRepository.save(existingCategory);
 	}
+
+	@Override
+	@Transactional(readOnly = true)
+	public Page<CategoryResponseDTO> getActiveCategories(Pageable pageable) {
+		log.debug("Fetching active categories with pagination: {}", pageable);
+		return categoryRepository.findByIsDeleteFalse(pageable)
+				.map(CategoryResponseDTO::fromEntity);
+	}
 }


### PR DESCRIPTION
### Problem
- `/getallcategories` currently returns all categories, including those marked as soft‑deleted (`isDelete = true`).
- Normal users expect only active categories, while admins may need to see everything.

### Solution
- Added repository method:
  ```java
  Page<Category> findByIsDeleteFalse(Pageable pageable);
  ```
- Implemented getActiveCategories(Pageable pageable) in CategoryService and CategoryServiceImpl.
- Exposed new endpoint:
   ``` GET /secure/api/v1/categories/activecategories ```
- Returns only active categories (isDelete = false).

### Impact
- Users: Only see active categories.
- Admins: Still see all categories.
- API behavior is now clear and predictable.

Close issue: #121
