### PR TITLE
fix(admin): make header logout button functional

### DIFF
--- a/RestroHub-FrontEnd/src/components/admin/Header.jsx
+++ b/RestroHub-FrontEnd/src/components/admin/Header.jsx
@@ -16,6 +16,7 @@ import {
 import { useNavigate } from 'react-router-dom';
 import { useAdminTheme } from '@context/AdminThemeContext';
 import useWebSocketNotifications from '@hooks/useWebSocketNotifications';
+import api from '../../services/common/api';
 
 const Header = ({ onMobileMenuClick, collapsed, onCollapseToggle }) => {
   const [searchOpen, setSearchOpen] = useState(false);
@@ -39,6 +40,23 @@ const Header = ({ onMobileMenuClick, collapsed, onCollapseToggle }) => {
     document.addEventListener('mousedown', handleClick);
     return () => document.removeEventListener('mousedown', handleClick);
   }, []);
+
+  const handleLogout = async () => {
+    try {
+      await api.post('/public/api/v1/auth/logout');  //handles logout on backend and invalidates refresh token
+    } catch (error) {
+      console.error('Logout API failed:', error);  //catches errors if API call breaks
+    } finally {
+      localStorage.removeItem('accessToken');
+      localStorage.removeItem('refreshToken');
+      localStorage.removeItem('roles');
+
+      if (api?.defaults?.headers?.common?.Authorization) {  //cleans up axios default auth header if it exists
+        delete api.defaults.headers.common.Authorization;
+      }
+      navigate('/login', { replace: true });
+    }
+  };
 
   // Live service request notifications via WebSocket
   // TODO: Replace hardcoded branchId with actual branch from auth context
@@ -298,6 +316,7 @@ const Header = ({ onMobileMenuClick, collapsed, onCollapseToggle }) => {
 
                 <div className={`border-t py-1 ${isDark ? 'border-gray-700' : 'border-gray-100'}`}>
                   <button
+                    onClick={handleLogout}
                     className="
                       flex w-full items-center gap-2.5 px-4 py-2.5
                       text-sm text-red-500 hover:bg-red-500/10 transition-colors


### PR DESCRIPTION
# Issue Link
Closes #209

# Changes Made
- Added a `handleLogout` function in `Header.jsx`
- Connected the logout handler to the "Sign Out" button in the admin profile dropdown
- Removed `accessToken` from `localStorage` on logout
- Redirected users to `/login` after signing out

# Type of Change
- Bug fix

# Testing Performed
- Verified logout removes `accessToken` from browser `localStorage`
- Verified user is redirected to `/login` after clicking "Sign Out"
- Verified protected admin routes are inaccessible after logout
- Checked for console errors during logout flow

# UI Changes
- No visual/UI changes
- "Sign Out" button is now functional

# Additional Notes
- This PR only focuses on fixing the logout functionality.
- Other authenticated profile related improvements are being handled separately in PR #198.