### PR TITLE
fix(validation): scoped duplicate checks for Category and Food

### DIFF
--- a/RestroHub/src/main/java/com/restroly/qrmenu/category/dto/CategoryRequestDTO.java
+++ b/RestroHub/src/main/java/com/restroly/qrmenu/category/dto/CategoryRequestDTO.java
@@ -3,6 +3,7 @@ package com.restroly.qrmenu.category.dto; // Changed package to fit category DTO
 import com.restroly.qrmenu.category.entity.Category;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -27,6 +28,10 @@ public class CategoryRequestDTO {
 
     @Schema(description = "Whether the category is marked for deletion (soft delete)")
     private Boolean isDelete; // Mirrors the field from the Category entity
+
+    @NotNull(message = "Menu ID is required")
+    private Long menuId;
+
 
     public static CategoryRequestDTO fromEntity(Category category) {
         if (category == null) return null;

--- a/RestroHub/src/main/java/com/restroly/qrmenu/category/dto/CategoryRequestDTO.java
+++ b/RestroHub/src/main/java/com/restroly/qrmenu/category/dto/CategoryRequestDTO.java
@@ -29,8 +29,8 @@ public class CategoryRequestDTO {
     @Schema(description = "Whether the category is marked for deletion (soft delete)")
     private Boolean isDelete; // Mirrors the field from the Category entity
 
-    @NotNull(message = "Menu ID is required")
-    private Long menuId;
+    @NotNull(message = "Branch ID is required")
+    private Long branchId; // Added branchId to link category to a branch
 
 
     public static CategoryRequestDTO fromEntity(Category category) {

--- a/RestroHub/src/main/java/com/restroly/qrmenu/category/entity/Category.java
+++ b/RestroHub/src/main/java/com/restroly/qrmenu/category/entity/Category.java
@@ -5,6 +5,7 @@ import java.time.LocalDateTime;
 import java.util.HashSet;
 import java.util.Set;
 
+import com.restroly.qrmenu.branch.entity.Branch;
 import com.restroly.qrmenu.food.entity.Food;
 import com.restroly.qrmenu.menu.entity.Menu;
 import jakarta.persistence.*;
@@ -46,6 +47,11 @@ public class Category {
     @Builder.Default
     @ManyToMany(mappedBy = "categories", fetch = FetchType.LAZY)
     private Set<Menu> menu = new HashSet<>();
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "branch_id", nullable = false)
+    private Branch branch;
+
 
     @PreUpdate
     protected void onUpdate() {

--- a/RestroHub/src/main/java/com/restroly/qrmenu/category/repository/CategoryRepository.java
+++ b/RestroHub/src/main/java/com/restroly/qrmenu/category/repository/CategoryRepository.java
@@ -16,6 +16,6 @@ public interface CategoryRepository extends JpaRepository<Category, Long> {
 
 	Page<Category> findByIsDeleteFalse(Pageable pageable);
 
-	boolean existsByNameIgnoreCaseAndMenu_MenuId(String name, Long menuId);
+	boolean existsByNameIgnoreCaseAndBranch_BranchId(String name, Long branchId);
 
 }

--- a/RestroHub/src/main/java/com/restroly/qrmenu/category/repository/CategoryRepository.java
+++ b/RestroHub/src/main/java/com/restroly/qrmenu/category/repository/CategoryRepository.java
@@ -16,4 +16,6 @@ public interface CategoryRepository extends JpaRepository<Category, Long> {
 
 	Page<Category> findByIsDeleteFalse(Pageable pageable);
 
+	boolean existsByNameIgnoreCaseAndMenu_MenuId(String name, Long menuId);
+
 }

--- a/RestroHub/src/main/java/com/restroly/qrmenu/category/service/CategoryServiceImpl.java
+++ b/RestroHub/src/main/java/com/restroly/qrmenu/category/service/CategoryServiceImpl.java
@@ -3,6 +3,8 @@ package com.restroly.qrmenu.category.service;
 import com.restroly.qrmenu.category.dto.CategoryRequestDTO;
 import com.restroly.qrmenu.category.dto.CategoryResponseDTO;
 import com.restroly.qrmenu.common.exception.ResourceNotFoundException;
+import com.restroly.qrmenu.menu.entity.Menu;
+import com.restroly.qrmenu.menu.repository.MenuRepository;
 import com.restroly.qrmenu.user.exception.DuplicateResourceException;
 
 import lombok.extern.slf4j.Slf4j;
@@ -24,6 +26,7 @@ import java.time.LocalDateTime;
 public class CategoryServiceImpl implements CategoryService {
 
 	private final CategoryRepository categoryRepository;
+	private final MenuRepository menuRepository;
 
 	/* =======================
        CREATE CATEGORY
@@ -38,6 +41,14 @@ public class CategoryServiceImpl implements CategoryService {
 			log.warn("Category with name '{}' already exists in menu '{}'", requestDTO.getName(), requestDTO.getMenuId());
 			throw new DuplicateResourceException("Category with name '" + requestDTO.getName() + "' already exists");
 		}
+
+		// Validate menu existence
+		Menu menu = menuRepository.findById(requestDTO.getMenuId())
+				.orElseThrow(() ->{
+					log.warn("Menu with ID '{}' not found for category creation", requestDTO.getMenuId());
+					return new ResourceNotFoundException("Menu with ID '" + requestDTO.getMenuId() + "' not found");
+				});
+
 		Category category = CategoryDTO.toEntity(
 				CategoryDTO.builder()
 						.name(requestDTO.getName())
@@ -46,6 +57,10 @@ public class CategoryServiceImpl implements CategoryService {
 						.updatedDate(LocalDateTime.now())
 						.build()
 		);
+
+		// Attach both sides of the relationship
+		category.getMenu().add(menu);
+		menu.getCategories().add(category);
 
 		Category savedCategory = categoryRepository.save(category);
 		log.info("Category created with ID: {}", savedCategory.getCategoryId());

--- a/RestroHub/src/main/java/com/restroly/qrmenu/category/service/CategoryServiceImpl.java
+++ b/RestroHub/src/main/java/com/restroly/qrmenu/category/service/CategoryServiceImpl.java
@@ -3,13 +3,13 @@ package com.restroly.qrmenu.category.service;
 import com.restroly.qrmenu.category.dto.CategoryRequestDTO;
 import com.restroly.qrmenu.category.dto.CategoryResponseDTO;
 import com.restroly.qrmenu.common.exception.ResourceNotFoundException;
-import com.restroly.qrmenu.menu.entity.Menu;
-import com.restroly.qrmenu.menu.repository.MenuRepository;
 import com.restroly.qrmenu.user.exception.DuplicateResourceException;
 
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 
+import com.restroly.qrmenu.branch.entity.Branch;
+import com.restroly.qrmenu.branch.repository.BranchRepository;
 import com.restroly.qrmenu.category.dto.CategoryDTO;
 import com.restroly.qrmenu.category.entity.Category;
 import com.restroly.qrmenu.category.repository.CategoryRepository;
@@ -26,7 +26,7 @@ import java.time.LocalDateTime;
 public class CategoryServiceImpl implements CategoryService {
 
 	private final CategoryRepository categoryRepository;
-	private final MenuRepository menuRepository;
+	private final BranchRepository branchRepository;
 
 	/* =======================
        CREATE CATEGORY
@@ -35,18 +35,18 @@ public class CategoryServiceImpl implements CategoryService {
 	public CategoryResponseDTO createCategory(CategoryRequestDTO requestDTO) {
 		log.debug("Creating category with name: {}", requestDTO.getName());
 
-		// Check for duplicate category name within the same menu
-		if(categoryRepository.existsByNameIgnoreCaseAndMenu_MenuId(
-				requestDTO.getName(), requestDTO.getMenuId())) {
-			log.warn("Category with name '{}' already exists in menu '{}'", requestDTO.getName(), requestDTO.getMenuId());
+		// Check for duplicate category name within the same branch
+		if(categoryRepository.existsByNameIgnoreCaseAndBranch_BranchId(
+				requestDTO.getName(), requestDTO.getBranchId())) {
+			log.warn("Category with name '{}' already exists in branch '{}'", requestDTO.getName(), requestDTO.getBranchId());
 			throw new DuplicateResourceException("Category with name '" + requestDTO.getName() + "' already exists");
 		}
 
-		// Validate menu existence
-		Menu menu = menuRepository.findById(requestDTO.getMenuId())
+		// Validate branch existence
+		Branch branch = branchRepository.findById(requestDTO.getBranchId())
 				.orElseThrow(() ->{
-					log.warn("Menu with ID '{}' not found for category creation", requestDTO.getMenuId());
-					return new ResourceNotFoundException("Menu with ID '" + requestDTO.getMenuId() + "' not found");
+					log.warn("Branch with ID '{}' not found for category creation", requestDTO.getBranchId());
+					return new ResourceNotFoundException("Branch with ID '" + requestDTO.getBranchId() + "' not found");
 				});
 
 		Category category = CategoryDTO.toEntity(
@@ -58,9 +58,8 @@ public class CategoryServiceImpl implements CategoryService {
 						.build()
 		);
 
-		// Attach both sides of the relationship
-		category.getMenu().add(menu);
-		menu.getCategories().add(category);
+		// Attach branch
+		category.setBranch(branch);
 
 		Category savedCategory = categoryRepository.save(category);
 		log.info("Category created with ID: {}", savedCategory.getCategoryId());

--- a/RestroHub/src/main/java/com/restroly/qrmenu/category/service/CategoryServiceImpl.java
+++ b/RestroHub/src/main/java/com/restroly/qrmenu/category/service/CategoryServiceImpl.java
@@ -3,6 +3,8 @@ package com.restroly.qrmenu.category.service;
 import com.restroly.qrmenu.category.dto.CategoryRequestDTO;
 import com.restroly.qrmenu.category.dto.CategoryResponseDTO;
 import com.restroly.qrmenu.common.exception.ResourceNotFoundException;
+import com.restroly.qrmenu.user.exception.DuplicateResourceException;
+
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 
@@ -29,6 +31,13 @@ public class CategoryServiceImpl implements CategoryService {
 	@Transactional
 	public CategoryResponseDTO createCategory(CategoryRequestDTO requestDTO) {
 		log.debug("Creating category with name: {}", requestDTO.getName());
+
+		// Check for duplicate category name within the same menu
+		if(categoryRepository.existsByNameIgnoreCaseAndMenu_MenuId(
+				requestDTO.getName(), requestDTO.getMenuId())) {
+			log.warn("Category with name '{}' already exists in menu '{}'", requestDTO.getName(), requestDTO.getMenuId());
+			throw new DuplicateResourceException("Category with name '" + requestDTO.getName() + "' already exists");
+		}
 		Category category = CategoryDTO.toEntity(
 				CategoryDTO.builder()
 						.name(requestDTO.getName())

--- a/RestroHub/src/main/java/com/restroly/qrmenu/food/repository/FoodRepository.java
+++ b/RestroHub/src/main/java/com/restroly/qrmenu/food/repository/FoodRepository.java
@@ -156,4 +156,7 @@ public interface FoodRepository extends JpaRepository<Food, Long> {
             @Param("id") Long id,
             @Param("available") Boolean available
     );
+
+    //Duplicate check scoped by category
+    boolean existsByNameIgnoreCaseAndCategory_CategoryId(String name, Long categoryId);
 }

--- a/RestroHub/src/main/java/com/restroly/qrmenu/food/repository/FoodRepository.java
+++ b/RestroHub/src/main/java/com/restroly/qrmenu/food/repository/FoodRepository.java
@@ -159,4 +159,7 @@ public interface FoodRepository extends JpaRepository<Food, Long> {
 
     //Duplicate check scoped by category
     boolean existsByNameIgnoreCaseAndCategory_CategoryId(String name, Long categoryId);
+
+    boolean existsByNameIgnoreCaseAndCategory_CategoryIdAndFoodIdNot(String name, Long categoryId, Long foodId);
+
 }

--- a/RestroHub/src/main/java/com/restroly/qrmenu/food/service/FoodServiceImpl.java
+++ b/RestroHub/src/main/java/com/restroly/qrmenu/food/service/FoodServiceImpl.java
@@ -165,15 +165,19 @@ public class FoodServiceImpl implements FoodService {
 
         Food existingFood = findFoodByIdOrThrow(id);
 
-        // Check for duplicate name within the same category if name is being updated
-        if (updateDTO.getName() != null &&
-            !updateDTO.getName().equalsIgnoreCase(existingFood.getName()) &&
-            foodRepository.existsByNameIgnoreCaseAndCategory_CategoryId(
-                updateDTO.getName(), existingFood.getCategory().getCategoryId())) {
+        // Check for duplicate name if name is being updated
+        if(updateDTO.getName() != null && !updateDTO.getName().equalsIgnoreCase(existingFood.getName())) {
+            // Determine the category ID to check
+            Long categoryIdToCheck = updateDTO.getCategoryId() != null ? updateDTO.getCategoryId() : existingFood.getCategory().getCategoryId();
 
-            log.warn("Attempt to update food with duplicate name '{}' in category '{}'",
-                    updateDTO.getName(), existingFood.getCategory().getCategoryId());
-            throw new ResourceAlreadyExistsException(String.format(FOOD_EXISTS_MSG, updateDTO.getName()));
+            // check for duplicate name in the target category, excluding the current food item
+            if(foodRepository.existsByNameIgnoreCaseAndCategory_CategoryIdAndFoodIdNot(
+                    updateDTO.getName(), categoryIdToCheck, id)) {
+                log.warn("Attempt to update food to duplicate name: {} in category id: {}",
+                        updateDTO.getName(), categoryIdToCheck);
+                throw new ResourceAlreadyExistsException("Food already exists with name: " + updateDTO.getName() +
+                        " in category id: " + categoryIdToCheck);
+            }
         }
 
         // Safe null check for imageUrl

--- a/RestroHub/src/main/java/com/restroly/qrmenu/food/service/FoodServiceImpl.java
+++ b/RestroHub/src/main/java/com/restroly/qrmenu/food/service/FoodServiceImpl.java
@@ -51,9 +51,15 @@ public class FoodServiceImpl implements FoodService {
     @Transactional
     @CacheEvict(value = "foods", allEntries = true)
     public FoodResponseDTO createFood(FoodRequestDTO requestDTO, MultipartFile image) {
-
-        if (foodRepository.existsByNameIgnoreCase(requestDTO.getName())) {
-            throw new ResourceAlreadyExistsException("Food already exists: " + requestDTO.getName());
+        log.debug("Creating new food with name: {}", requestDTO.getName());
+        
+        // duplicate name check scoped by category
+        if(foodRepository.existsByNameIgnoreCaseAndCategory_CategoryId(
+            requestDTO.getName(), requestDTO.getCategoryId())) {
+            log.warn("Attempt to create duplicate food with name: {} in category: {}",
+                    requestDTO.getName(), requestDTO.getCategoryId());
+            throw new ResourceAlreadyExistsException("Food already exists with name: " + requestDTO.getName() +
+                    " in category id: " + requestDTO.getCategoryId());
         }
 
         String imageUrl = null;
@@ -159,14 +165,15 @@ public class FoodServiceImpl implements FoodService {
 
         Food existingFood = findFoodByIdOrThrow(id);
 
-        // Check for duplicate name if name is being updated
+        // Check for duplicate name within the same category if name is being updated
         if (updateDTO.getName() != null &&
-                !updateDTO.getName().equalsIgnoreCase(existingFood.getName()) &&
-                foodRepository.existsByNameIgnoreCase(updateDTO.getName())) {
+            !updateDTO.getName().equalsIgnoreCase(existingFood.getName()) &&
+            foodRepository.existsByNameIgnoreCaseAndCategory_CategoryId(
+                updateDTO.getName(), existingFood.getCategory().getCategoryId())) {
 
-            log.warn("Attempt to update food with duplicate name: {}", updateDTO.getName());
-            throw new ResourceAlreadyExistsException(
-                    String.format(FOOD_EXISTS_MSG, updateDTO.getName()));
+            log.warn("Attempt to update food with duplicate name '{}' in category '{}'",
+                    updateDTO.getName(), existingFood.getCategory().getCategoryId());
+            throw new ResourceAlreadyExistsException(String.format(FOOD_EXISTS_MSG, updateDTO.getName()));
         }
 
         // Safe null check for imageUrl


### PR DESCRIPTION
## Summary
This PR introduces corrected duplicate validation logic to ensure data integrity:

- **Category**: Added per‑menu duplicate name validation using `existsByNameIgnoreCaseAndMenu_MenuId`.
- **Food**: Added per‑category duplicate name validation using `existsByNameIgnoreCaseAndCategory_CategoryId`.

## Why
The earlier PR (#160) attempted similar changes but contained bugs. This new PR provides a clean, corrected implementation with proper repository methods and service logic.

## Notes
- Other modules (Menu, Order, Restaurant, User) already had scoped validation checks in place.
- This PR focuses only on the missing pieces (Category and Food).
- If additional validation is expected, please highlight it so I can address it in a follow‑up.

Close Issue: #156 
