### PR TITLE
fix(frontend): add ESLint v9 flat config

### DIFF
--- a/RestroHub-FrontEnd/eslint.config.js
+++ b/RestroHub-FrontEnd/eslint.config.js
@@ -1,0 +1,71 @@
+import react from 'eslint-plugin-react';
+import reactHooks from 'eslint-plugin-react-hooks';
+import reactRefresh from 'eslint-plugin-react-refresh';
+
+const browserGlobals = {
+  Blob: 'readonly',
+  FormData: 'readonly',
+  URL: 'readonly',
+  clearInterval: 'readonly',
+  clearTimeout: 'readonly',
+  console: 'readonly',
+  document: 'readonly',
+  fetch: 'readonly',
+  localStorage: 'readonly',
+  setInterval: 'readonly',
+  setTimeout: 'readonly',
+  window: 'readonly',
+};
+
+export default [
+  {
+    ignores: ['dist/**', 'node_modules/**'],
+  },
+  {
+    files: ['src/**/*.{js,jsx}'],
+    languageOptions: {
+      ecmaVersion: 'latest',
+      sourceType: 'module',
+      parserOptions: {
+        ecmaFeatures: {
+          jsx: true,
+        },
+      },
+      globals: browserGlobals,
+    },
+    plugins: {
+      react,
+      'react-hooks': reactHooks,
+      'react-refresh': reactRefresh,
+    },
+    settings: {
+      react: {
+        version: 'detect',
+      },
+    },
+    rules: {
+      ...react.configs.recommended.rules,
+      ...reactHooks.configs.recommended.rules,
+      'react/display-name': 'off',
+      'react/jsx-uses-react': 'off',
+      'react/no-unescaped-entities': 'off',
+      'react/react-in-jsx-scope': 'off',
+      'react/prop-types': 'off',
+      'react-hooks/immutability': 'off',
+      'react-hooks/set-state-in-effect': 'off',
+      'react-refresh/only-export-components': [
+        'warn',
+        { allowConstantExport: true },
+      ],
+      'no-console': 'off',
+      'no-unused-vars': [
+        'warn',
+        {
+          argsIgnorePattern: '^_',
+          ignoreRestSiblings: true,
+          varsIgnorePattern: '^_',
+        },
+      ],
+    },
+  },
+];


### PR DESCRIPTION
## Issue Link
Closes #218

## Changes Made
- Added ESLint v9 flat configuration for the React frontend.
- Configured existing React, React Hooks, and React Refresh ESLint plugins.
- Added browser globals and ignored generated/dependency folders.

## Type of Change
- [x] Bug fix

## Testing Performed
- [x] Ran `npm.cmd run lint` successfully
  - Result: passed with 0 errors; existing warnings are reported.
- [x] Ran `npm.cmd run build` successfully
  - Result: production build completed.

## Additional Notes
- This fixes the missing `eslint.config.js` error introduced by ESLint v9.