### PR TITLE
feat(tables): implement real table management APIs

### DIFF
--- a/RestroHub-FrontEnd/src/components/admin/store/tables/TableCard.jsx
+++ b/RestroHub-FrontEnd/src/components/admin/store/tables/TableCard.jsx
@@ -1,8 +1,21 @@
 import { useState } from 'react';
-import { QrCode, Edit2, Trash2, Users, Loader2 } from 'lucide-react';
+import { QrCode, Edit2, Trash2, Users, Loader2, RotateCcw } from 'lucide-react';
+import api from '@services/common/api';
 
-const TableCard = ({ table, onShowQR, onEdit, onDelete }) => {
-  const [deleting, setDeleting] = useState(false);
+const normalizeTable = (table) => ({
+  id: table.tableId,
+  tableId: table.tableId,
+  branchId: table.branchId,
+  number: table.tableNumber,
+  tableNumber: table.tableNumber,
+  capacity: table.capacity || 4,
+  status: table.status || 'available',
+  qrCodeUrl: table.qrCodeUrl,
+  isActive: table.isActive !== false,
+});
+
+const TableCard = ({ table, onShowQR, onEdit, onDelete, onRestore }) => {
+  const [saving, setSaving] = useState(false);
 
   const statusStyles = {
     available: {
@@ -23,38 +36,58 @@ const TableCard = ({ table, onShowQR, onEdit, onDelete }) => {
       dot: 'bg-yellow-500',
       numberBg: 'bg-yellow-50',
     },
+    inactive: {
+      border: 'border-gray-200 hover:border-gray-300',
+      badge: 'bg-gray-100 text-gray-600',
+      dot: 'bg-gray-400',
+      numberBg: 'bg-gray-50',
+    },
   };
 
-  const styles = statusStyles[table.status] || statusStyles.available;
+  const displayStatus = table.isActive ? table.status : 'inactive';
+  const styles = statusStyles[displayStatus] || statusStyles.available;
 
   const handleDelete = async (e) => {
     e.stopPropagation();
     if (!window.confirm(`Delete Table ${table.number}?`)) return;
+
     try {
-      setDeleting(true);
-      // 🔌 await api.delete(`/api/tables/${table.id}`);
-      await new Promise((r) => setTimeout(r, 300));
-      onDelete(table.id);
+      setSaving(true);
+      await api.delete(`/secure/api/v1/tables/${table.id}`);
+      onDelete({ ...table, isActive: false });
     } catch (err) {
       console.error('Delete failed:', err);
+      alert(err.response?.data?.message || 'Failed to delete table');
     } finally {
-      setDeleting(false);
+      setSaving(false);
+    }
+  };
+
+  const handleRestore = async (e) => {
+    e.stopPropagation();
+
+    try {
+      setSaving(true);
+      const response = await api.patch(`/secure/api/v1/tables/${table.id}/restore`);
+      onRestore(normalizeTable(response.data));
+    } catch (err) {
+      console.error('Restore failed:', err);
+      alert(err.response?.data?.message || 'Failed to restore table');
+    } finally {
+      setSaving(false);
     }
   };
 
   return (
     <div
-      onClick={() => onShowQR(table)}
+      onClick={() => table.isActive && onShowQR(table)}
       className={`
-        cursor-pointer overflow-hidden rounded-2xl border-2
-        bg-white transition-all duration-200
-        hover:shadow-lg
+        overflow-hidden rounded-2xl border-2 bg-white transition-all duration-200
+        ${table.isActive ? 'cursor-pointer hover:shadow-lg' : 'opacity-75'}
         ${styles.border}
       `}
     >
-      {/* Body */}
       <div className="px-3 py-4 text-center sm:px-4 sm:py-5">
-        {/* Number Circle */}
         <div
           className={`
             mx-auto mb-2 flex items-center justify-center
@@ -68,18 +101,15 @@ const TableCard = ({ table, onShowQR, onEdit, onDelete }) => {
           </span>
         </div>
 
-        {/* Label */}
         <p className="text-xs font-semibold text-gray-900 sm:text-sm">
           Table {table.number}
         </p>
 
-        {/* Capacity */}
         <div className="mt-1 flex items-center justify-center gap-1 text-gray-600">
           <Users className="h-3 w-3 sm:h-3.5 sm:w-3.5" />
           <span className="text-xs sm:text-sm">{table.capacity} seats</span>
         </div>
 
-        {/* Status Badge */}
         <div className="mt-2 flex items-center justify-center">
           <span
             className={`
@@ -89,52 +119,56 @@ const TableCard = ({ table, onShowQR, onEdit, onDelete }) => {
             `}
           >
             <span className={`inline-block h-1.5 w-1.5 rounded-full ${styles.dot}`} />
-            {table.status}
+            {displayStatus}
           </span>
         </div>
       </div>
 
-      {/* Actions Footer */}
       <div className="flex items-center justify-center gap-1 border-t border-gray-100 px-2 py-2 sm:gap-2 sm:px-3 sm:py-3">
-        <button
-          onClick={(e) => { e.stopPropagation(); onShowQR(table); }}
-          className="
-            inline-flex h-8 w-8 items-center justify-center
-            rounded-lg bg-blue-50 text-blue-600
-            hover:bg-blue-100 transition-colors
-          "
-          title="View QR"
-        >
-          <QrCode className="h-3.5 w-3.5 sm:h-4 sm:w-4" />
-        </button>
-        <button
-          onClick={(e) => { e.stopPropagation(); onEdit?.(table); }}
-          className="
-            inline-flex h-8 w-8 items-center justify-center
-            rounded-lg bg-gray-50 text-gray-600
-            hover:bg-gray-100 transition-colors
-          "
-          title="Edit"
-        >
-          <Edit2 className="h-3.5 w-3.5 sm:h-4 sm:w-4" />
-        </button>
-        <button
-          onClick={handleDelete}
-          disabled={deleting}
-          className="
-            inline-flex h-8 w-8 items-center justify-center
-            rounded-lg bg-red-50 text-red-600
-            hover:bg-red-100 transition-colors
-            disabled:opacity-50
-          "
-          title="Delete"
-        >
-          {deleting ? (
-            <Loader2 className="h-3.5 w-3.5 animate-spin" />
-          ) : (
-            <Trash2 className="h-3.5 w-3.5 sm:h-4 sm:w-4" />
-          )}
-        </button>
+        {table.isActive ? (
+          <>
+            <button
+              onClick={(e) => { e.stopPropagation(); onShowQR(table); }}
+              className="inline-flex h-8 w-8 items-center justify-center rounded-lg bg-blue-50 text-blue-600 transition-colors hover:bg-blue-100"
+              title="View QR"
+            >
+              <QrCode className="h-3.5 w-3.5 sm:h-4 sm:w-4" />
+            </button>
+            <button
+              onClick={(e) => { e.stopPropagation(); onEdit?.(table); }}
+              className="inline-flex h-8 w-8 items-center justify-center rounded-lg bg-gray-50 text-gray-600 transition-colors hover:bg-gray-100"
+              title="Edit"
+            >
+              <Edit2 className="h-3.5 w-3.5 sm:h-4 sm:w-4" />
+            </button>
+            <button
+              onClick={handleDelete}
+              disabled={saving}
+              className="inline-flex h-8 w-8 items-center justify-center rounded-lg bg-red-50 text-red-600 transition-colors hover:bg-red-100 disabled:opacity-50"
+              title="Delete"
+            >
+              {saving ? (
+                <Loader2 className="h-3.5 w-3.5 animate-spin" />
+              ) : (
+                <Trash2 className="h-3.5 w-3.5 sm:h-4 sm:w-4" />
+              )}
+            </button>
+          </>
+        ) : (
+          <button
+            onClick={handleRestore}
+            disabled={saving}
+            className="inline-flex h-8 items-center justify-center gap-2 rounded-lg bg-blue-50 px-3 text-xs font-medium text-blue-700 transition-colors hover:bg-blue-100 disabled:opacity-50"
+            title="Restore"
+          >
+            {saving ? (
+              <Loader2 className="h-3.5 w-3.5 animate-spin" />
+            ) : (
+              <RotateCcw className="h-3.5 w-3.5" />
+            )}
+            Restore
+          </button>
+        )}
       </div>
     </div>
   );

--- a/RestroHub-FrontEnd/src/components/admin/store/tables/TableCard.jsx
+++ b/RestroHub-FrontEnd/src/components/admin/store/tables/TableCard.jsx
@@ -1,18 +1,7 @@
 import { useState } from 'react';
 import { QrCode, Edit2, Trash2, Users, Loader2, RotateCcw } from 'lucide-react';
 import api from '@services/common/api';
-
-const normalizeTable = (table) => ({
-  id: table.tableId,
-  tableId: table.tableId,
-  branchId: table.branchId,
-  number: table.tableNumber,
-  tableNumber: table.tableNumber,
-  capacity: table.capacity || 4,
-  status: table.status || 'available',
-  qrCodeUrl: table.qrCodeUrl,
-  isActive: table.isActive !== false,
-});
+import { normalizeTable } from './tableMapper';
 
 const TableCard = ({ table, onShowQR, onEdit, onDelete, onRestore }) => {
   const [saving, setSaving] = useState(false);

--- a/RestroHub-FrontEnd/src/components/admin/store/tables/TableFormModal.jsx
+++ b/RestroHub-FrontEnd/src/components/admin/store/tables/TableFormModal.jsx
@@ -1,24 +1,60 @@
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import { X, Loader2, LayoutGrid } from 'lucide-react';
 import { Dialog } from '@headlessui/react';
+import api from '@services/common/api';
 
-const TableFormModal = ({ isOpen, onClose, branchId }) => {
-  const [formData, setFormData] = useState({ number: '', capacity: '' });
+const TableFormModal = ({ isOpen, onClose, onSaved, branchId, editingTable }) => {
+  const [formData, setFormData] = useState({
+    number: '',
+    capacity: '',
+    status: 'available',
+  });
   const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState(null);
+
+  useEffect(() => {
+    if (editingTable) {
+      setFormData({
+        number: editingTable.number || '',
+        capacity: editingTable.capacity || '',
+        status: editingTable.status || 'available',
+      });
+    } else {
+      setFormData({ number: '', capacity: '', status: 'available' });
+    }
+    setError(null);
+  }, [editingTable, isOpen]);
 
   const handleSubmit = async (e) => {
     e.preventDefault();
+    setSubmitting(true);
+    setError(null);
+
     try {
-      setSubmitting(true);
-      // 🔌 API call
-      await new Promise((r) => setTimeout(r, 500));
+      const payload = {
+        tableNumber: Number(formData.number),
+        capacity: Number(formData.capacity),
+        status: formData.status,
+      };
+
+      if (editingTable) {
+        await api.put(`/secure/api/v1/tables/${editingTable.id}`, payload);
+      } else {
+        await api.post(`/secure/api/v1/branches/${branchId}/tables`, payload);
+      }
+
+      onSaved?.();
       onClose();
-      setFormData({ number: '', capacity: '' });
     } catch (err) {
       console.error('Failed:', err);
+      setError(err.response?.data?.message || 'Failed to save table');
     } finally {
       setSubmitting(false);
     }
+  };
+
+  const updateField = (field, value) => {
+    setFormData((prev) => ({ ...prev, [field]: value }));
   };
 
   const inputClass = `
@@ -38,14 +74,13 @@ const TableFormModal = ({ isOpen, onClose, branchId }) => {
             border border-gray-200 bg-white shadow-xl
           "
         >
-          {/* Header */}
           <div className="flex items-center justify-between border-b border-gray-100 px-5 py-4">
             <div className="flex items-center gap-3">
               <div className="flex h-10 w-10 items-center justify-center rounded-xl bg-blue-50">
                 <LayoutGrid className="h-5 w-5 text-blue-600" />
               </div>
               <Dialog.Title className="text-lg font-bold text-gray-900">
-                Add New Table
+                {editingTable ? 'Edit Table' : 'Add New Table'}
               </Dialog.Title>
             </div>
             <button
@@ -59,17 +94,23 @@ const TableFormModal = ({ isOpen, onClose, branchId }) => {
             </button>
           </div>
 
-          {/* Form */}
           <form onSubmit={handleSubmit}>
             <div className="space-y-4 px-5 py-5">
+              {error && (
+                <div className="rounded-lg border border-red-200 bg-red-50 px-3 py-2 text-sm text-red-600">
+                  {error}
+                </div>
+              )}
+
               <div>
                 <label className="mb-1.5 block text-sm font-medium text-gray-800">
                   Table Number
                 </label>
                 <input
                   type="number"
+                  min="1"
                   value={formData.number}
-                  onChange={(e) => setFormData({ ...formData, number: e.target.value })}
+                  onChange={(e) => updateField('number', e.target.value)}
                   className={inputClass}
                   placeholder="9"
                   required
@@ -81,16 +122,30 @@ const TableFormModal = ({ isOpen, onClose, branchId }) => {
                 </label>
                 <input
                   type="number"
+                  min="1"
                   value={formData.capacity}
-                  onChange={(e) => setFormData({ ...formData, capacity: e.target.value })}
+                  onChange={(e) => updateField('capacity', e.target.value)}
                   className={inputClass}
                   placeholder="4"
                   required
                 />
               </div>
+              <div>
+                <label className="mb-1.5 block text-sm font-medium text-gray-800">
+                  Status
+                </label>
+                <select
+                  value={formData.status}
+                  onChange={(e) => updateField('status', e.target.value)}
+                  className={inputClass}
+                >
+                  <option value="available">Available</option>
+                  <option value="occupied">Occupied</option>
+                  <option value="reserved">Reserved</option>
+                </select>
+              </div>
             </div>
 
-            {/* Footer */}
             <div className="flex items-center gap-3 border-t border-gray-100 px-5 py-4">
               <button
                 type="button"
@@ -116,7 +171,7 @@ const TableFormModal = ({ isOpen, onClose, branchId }) => {
                 "
               >
                 {submitting && <Loader2 className="h-4 w-4 animate-spin" />}
-                Add Table
+                {editingTable ? 'Update Table' : 'Add Table'}
               </button>
             </div>
           </form>
@@ -126,4 +181,4 @@ const TableFormModal = ({ isOpen, onClose, branchId }) => {
   );
 };
 
-export default TableFormModal;  
+export default TableFormModal;

--- a/RestroHub-FrontEnd/src/components/admin/store/tables/TableQRModal.jsx
+++ b/RestroHub-FrontEnd/src/components/admin/store/tables/TableQRModal.jsx
@@ -8,7 +8,7 @@ const TableQRModal = ({ isOpen, onClose, table, branchId }) => {
 
   if (!table) return null;
 
-  const qrUrl = `${window.location.origin}/Restrohub/RajkotDhaba/${branchId}?table=${table.number}`;
+  const qrUrl = `${window.location.origin}/Restrohub/RajkotDhaba/${branchId}?tableId=${table.id}&table=${table.number}`;
 
   const handleDownload = async () => {
     try {
@@ -35,7 +35,7 @@ const TableQRModal = ({ isOpen, onClose, table, branchId }) => {
           {/* Header */}
           <div className="flex items-center justify-between border-b border-gray-100 px-5 py-4">
             <Dialog.Title className="text-lg font-bold text-gray-900">
-              Table {table.number} — QR Code
+              Table {table.number} - QR Code
             </Dialog.Title>
             <button
               onClick={onClose}

--- a/RestroHub-FrontEnd/src/components/admin/store/tables/Tables.jsx
+++ b/RestroHub-FrontEnd/src/components/admin/store/tables/Tables.jsx
@@ -9,19 +9,23 @@ import TableQRModal from './TableQRModal';
 const Tables = () => {
   const { branchId } = useParams();
   const [isAddOpen, setIsAddOpen] = useState(false);
+  const [editingTable, setEditingTable] = useState(null);
   const [selectedTable, setSelectedTable] = useState(null);
   const [showQR, setShowQR] = useState(false);
   const [allTables, setAllTables] = useState([]);
+  const [refreshKey, setRefreshKey] = useState(0);
 
   const openQR = (table) => { setSelectedTable(table); setShowQR(true); };
   const closeQR = () => { setShowQR(false); setSelectedTable(null); };
+  const closeForm = () => { setIsAddOpen(false); setEditingTable(null); };
+  const refreshTables = () => setRefreshKey((key) => key + 1);
 
   return (
     <div className="space-y-5 sm:space-y-6">
       <TablesHeader
         branchId={branchId}
         onAddTable={() => setIsAddOpen(true)}
-        totalTables={allTables.length}
+        totalTables={allTables.filter((table) => table.isActive !== false).length}
       />
 
       <TablesStatusLegend tables={allTables} />
@@ -29,12 +33,16 @@ const Tables = () => {
       <TablesGrid
         branchId={branchId}
         onShowQR={openQR}
+        onEdit={(table) => { setEditingTable(table); setIsAddOpen(true); }}
         onTablesLoaded={setAllTables}
+        refreshKey={refreshKey}
       />
 
       <TableFormModal
         isOpen={isAddOpen}
-        onClose={() => setIsAddOpen(false)}
+        onClose={closeForm}
+        onSaved={refreshTables}
+        editingTable={editingTable}
         branchId={branchId}
       />
 

--- a/RestroHub-FrontEnd/src/components/admin/store/tables/TablesGrid.jsx
+++ b/RestroHub-FrontEnd/src/components/admin/store/tables/TablesGrid.jsx
@@ -1,47 +1,63 @@
 import { useState, useEffect } from 'react';
 import { RefreshCw, AlertCircle, LayoutGrid } from 'lucide-react';
+import api from '@services/common/api';
 import TableCard from './TableCard';
 import AdminSkeleton from '../../AdminSkeleton';
 
-const TablesGrid = ({ branchId, onShowQR, onTablesLoaded }) => {
+const normalizeTable = (table) => ({
+  id: table.tableId,
+  tableId: table.tableId,
+  branchId: table.branchId,
+  number: table.tableNumber,
+  tableNumber: table.tableNumber,
+  capacity: table.capacity || 4,
+  status: table.status || 'available',
+  qrCodeUrl: table.qrCodeUrl,
+  isActive: table.isActive !== false,
+});
+
+const TablesGrid = ({ branchId, onShowQR, onEdit, onTablesLoaded, refreshKey }) => {
   const [tables, setTables] = useState([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState(null);
 
-  const fallbackTables = [
-    { id: 1, number: 1, capacity: 4, status: 'available' },
-    { id: 2, number: 2, capacity: 2, status: 'occupied' },
-    { id: 3, number: 3, capacity: 6, status: 'available' },
-    { id: 4, number: 4, capacity: 4, status: 'occupied' },
-    { id: 5, number: 5, capacity: 8, status: 'reserved' },
-    { id: 6, number: 6, capacity: 4, status: 'available' },
-    { id: 7, number: 7, capacity: 2, status: 'available' },
-    { id: 8, number: 8, capacity: 4, status: 'occupied' },
-  ];
-
   useEffect(() => {
     fetchTables();
-  }, [branchId]);
+  }, [branchId, refreshKey]);
 
   const fetchTables = async () => {
+    if (!branchId) {
+      setTables([]);
+      onTablesLoaded?.([]);
+      setLoading(false);
+      return;
+    }
+
     try {
       setLoading(true);
       setError(null);
-      // 🔌 const response = await api.get(`/api/branches/${branchId}/tables`);
-      await new Promise((r) => setTimeout(r, 500));
-      setTables(fallbackTables);
-      onTablesLoaded?.(fallbackTables);
+      const response = await api.get(`/secure/api/v1/branches/${branchId}/tables`);
+      const tableList = (response.data || []).map(normalizeTable);
+      setTables(tableList);
+      onTablesLoaded?.(tableList);
     } catch (err) {
       console.error('Fetch failed:', err);
       setError('Failed to load tables');
-      setTables(fallbackTables);
+      setTables([]);
+      onTablesLoaded?.([]);
     } finally {
       setLoading(false);
     }
   };
 
-  const handleDelete = (id) => {
-    setTables((prev) => prev.filter((t) => t.id !== id));
+  const updateTableState = (updatedTable) => {
+    setTables((prev) => {
+      const next = prev.map((table) => (
+        table.id === updatedTable.id ? updatedTable : table
+      ));
+      onTablesLoaded?.(next);
+      return next;
+    });
   };
 
   if (loading) {
@@ -86,13 +102,15 @@ const TablesGrid = ({ branchId, onShowQR, onTablesLoaded }) => {
             key={table.id}
             table={table}
             onShowQR={onShowQR}
-            onDelete={handleDelete}
+            onEdit={onEdit}
+            onDelete={updateTableState}
+            onRestore={updateTableState}
           />
         ))}
       </div>
       <p className="mt-4 text-center text-xs text-gray-500 sm:text-sm">
-        {tables.length} tables •{' '}
-        {tables.filter((t) => t.status === 'available').length} available
+        {tables.filter((t) => t.isActive).length} active tables -{' '}
+        {tables.filter((t) => t.isActive && t.status === 'available').length} available
       </p>
     </div>
   );

--- a/RestroHub-FrontEnd/src/components/admin/store/tables/TablesGrid.jsx
+++ b/RestroHub-FrontEnd/src/components/admin/store/tables/TablesGrid.jsx
@@ -3,18 +3,7 @@ import { RefreshCw, AlertCircle, LayoutGrid } from 'lucide-react';
 import api from '@services/common/api';
 import TableCard from './TableCard';
 import AdminSkeleton from '../../AdminSkeleton';
-
-const normalizeTable = (table) => ({
-  id: table.tableId,
-  tableId: table.tableId,
-  branchId: table.branchId,
-  number: table.tableNumber,
-  tableNumber: table.tableNumber,
-  capacity: table.capacity || 4,
-  status: table.status || 'available',
-  qrCodeUrl: table.qrCodeUrl,
-  isActive: table.isActive !== false,
-});
+import { normalizeTable } from './tableMapper';
 
 const TablesGrid = ({ branchId, onShowQR, onEdit, onTablesLoaded, refreshKey }) => {
   const [tables, setTables] = useState([]);
@@ -29,6 +18,7 @@ const TablesGrid = ({ branchId, onShowQR, onEdit, onTablesLoaded, refreshKey }) 
     if (!branchId) {
       setTables([]);
       onTablesLoaded?.([]);
+      setError(null);
       setLoading(false);
       return;
     }

--- a/RestroHub-FrontEnd/src/components/admin/store/tables/TablesStatusLegend.jsx
+++ b/RestroHub-FrontEnd/src/components/admin/store/tables/TablesStatusLegend.jsx
@@ -1,8 +1,9 @@
 const TablesStatusLegend = ({ tables = [] }) => {
+  const activeTables = tables.filter((table) => table.isActive !== false);
   const counts = {
-    available: tables.filter((t) => t.status === 'available').length,
-    occupied: tables.filter((t) => t.status === 'occupied').length,
-    reserved: tables.filter((t) => t.status === 'reserved').length,
+    available: activeTables.filter((t) => t.status === 'available').length,
+    occupied: activeTables.filter((t) => t.status === 'occupied').length,
+    reserved: activeTables.filter((t) => t.status === 'reserved').length,
   };
 
   const statuses = [

--- a/RestroHub-FrontEnd/src/components/admin/store/tables/tableMapper.js
+++ b/RestroHub-FrontEnd/src/components/admin/store/tables/tableMapper.js
@@ -1,0 +1,11 @@
+export const normalizeTable = (table) => ({
+  id: table.tableId,
+  tableId: table.tableId,
+  branchId: table.branchId,
+  number: table.tableNumber,
+  tableNumber: table.tableNumber,
+  capacity: table.capacity || 4,
+  status: table.status || 'available',
+  qrCodeUrl: table.qrCodeUrl,
+  isActive: table.isActive !== false,
+});

--- a/RestroHub/src/main/java/com/restroly/qrmenu/branch/dto/BranchResponseDTO.java
+++ b/RestroHub/src/main/java/com/restroly/qrmenu/branch/dto/BranchResponseDTO.java
@@ -106,6 +106,10 @@ public class BranchResponseDTO {
 
         private Integer tableNumber;
 
+        private Integer capacity;
+
+        private String status;
+
         private String qrCodeUrl;
 
         private Boolean isActive;

--- a/RestroHub/src/main/java/com/restroly/qrmenu/branch/mapper/BranchMapper.java
+++ b/RestroHub/src/main/java/com/restroly/qrmenu/branch/mapper/BranchMapper.java
@@ -46,7 +46,7 @@ public class BranchMapper {
                 .address(toAddressDTO(branch.getAddress()))
                 .menu(toMenuDTO(branch.getMenu()))
                 .tables(toTableDTOList(branch.getTables()))
-                .tableCount(branch.getTables() != null ? branch.getTables().size() : 0)
+                .tableCount(countActiveTables(branch.getTables()))
                 .build();
     }
 
@@ -61,7 +61,7 @@ public class BranchMapper {
                 .isDelete(branch.getIsDelete())
                 .createdDate(branch.getCreatedDate())
                 .address(toAddressDTO(branch.getAddress()))
-                .tableCount(branch.getTables() != null ? branch.getTables().size() : 0)
+                .tableCount(countActiveTables(branch.getTables()))
                 .build();
     }
 
@@ -170,6 +170,8 @@ public class BranchMapper {
         return BranchResponseDTO.TableDTO.builder()
                 .tableId(table.getTableId())
                 .tableNumber(table.getTableNumber())
+                .capacity(table.getCapacity())
+                .status(table.getStatus())
                 .qrCodeUrl(table.getQrCodeUrl())
                 .isActive(table.getIsActive())
                 .build();
@@ -180,6 +182,13 @@ public class BranchMapper {
         return tables.stream()
                 .map(this::toTableDTO)
                 .collect(Collectors.toList());
+    }
+
+    private int countActiveTables(List<Tables> tables) {
+        if (tables == null) return 0;
+        return (int) tables.stream()
+                .filter(table -> Boolean.TRUE.equals(table.getIsActive()))
+                .count();
     }
 
     private String buildFullAddress(Address address) {

--- a/RestroHub/src/main/java/com/restroly/qrmenu/config/SecurityConfig.java
+++ b/RestroHub/src/main/java/com/restroly/qrmenu/config/SecurityConfig.java
@@ -62,9 +62,10 @@ public class SecurityConfig {
 				.authorizeHttpRequests(auth -> auth
 						.requestMatchers(PUBLIC_URLS).permitAll()
 						.requestMatchers(HttpMethod.GET, PUBLIC_GET_URLS).permitAll()
-						.requestMatchers(HttpMethod.POST, "/secure/api/**").hasAnyRole("ADMIN", "RESTAURANT_OWNER")
-						.requestMatchers(HttpMethod.PUT, "/secure/api/**").hasAnyRole("ADMIN", "RESTAURANT_OWNER")
-						.requestMatchers(HttpMethod.DELETE, "/secure/api/**").hasAnyRole("ADMIN", "RESTAURANT_OWNER")
+						.requestMatchers(HttpMethod.POST, "/secure/api/**").hasAnyRole("ADMIN", "MANAGER", "RESTAURANT_OWNER")
+						.requestMatchers(HttpMethod.PUT, "/secure/api/**").hasAnyRole("ADMIN", "MANAGER", "RESTAURANT_OWNER")
+						.requestMatchers(HttpMethod.PATCH, "/secure/api/**").hasAnyRole("ADMIN", "MANAGER", "RESTAURANT_OWNER")
+						.requestMatchers(HttpMethod.DELETE, "/secure/api/**").hasAnyRole("ADMIN", "MANAGER", "RESTAURANT_OWNER")
 						// All other requests require authentication
 						.anyRequest().authenticated()
 				)

--- a/RestroHub/src/main/java/com/restroly/qrmenu/table/controller/TableController.java
+++ b/RestroHub/src/main/java/com/restroly/qrmenu/table/controller/TableController.java
@@ -1,0 +1,136 @@
+package com.restroly.qrmenu.table.controller;
+
+import com.restroly.qrmenu.common.exception.ErrorResponse;
+import com.restroly.qrmenu.common.util.ApiConstants;
+import com.restroly.qrmenu.table.dto.TableRequestDTO;
+import com.restroly.qrmenu.table.dto.TableResponseDTO;
+import com.restroly.qrmenu.table.service.TableService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.*;
+
+import java.net.URI;
+import java.util.List;
+
+import static com.restroly.qrmenu.common.util.ApiConstants.SECURE_API_VERSION;
+
+@RestController
+@RequestMapping(SECURE_API_VERSION)
+@RequiredArgsConstructor
+@Slf4j
+@Validated
+@Tag(name = "Table Management", description = "APIs for managing branch tables")
+public class TableController {
+
+    private final TableService tableService;
+
+    @GetMapping(value = "/branches/{branchId}/tables", produces = MediaType.APPLICATION_JSON_VALUE)
+    @Operation(summary = "Get tables by branch", description = "Retrieves all tables for a branch")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "Successfully retrieved tables"),
+            @ApiResponse(responseCode = "404", description = "Branch not found",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
+    })
+    public ResponseEntity<List<TableResponseDTO>> getTablesByBranch(
+            @Parameter(description = "ID of the branch", required = true)
+            @PathVariable Long branchId) {
+
+        log.debug("REST request to get tables for branch id: {}", branchId);
+        return ResponseEntity.ok(tableService.getTablesByBranch(branchId));
+    }
+
+    @PostMapping(value = "/branches/{branchId}/tables",
+            consumes = MediaType.APPLICATION_JSON_VALUE,
+            produces = MediaType.APPLICATION_JSON_VALUE)
+    @PreAuthorize("hasRole('ADMIN') or hasRole('MANAGER')")
+    @Operation(
+            summary = "Create a table",
+            description = "Creates a new table for a branch. Requires ADMIN or MANAGER role.",
+            security = @SecurityRequirement(name = "bearerAuth")
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "201", description = "Table created successfully",
+                    content = @Content(schema = @Schema(implementation = TableResponseDTO.class))),
+            @ApiResponse(responseCode = "400", description = "Invalid input data",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+            @ApiResponse(responseCode = "404", description = "Branch not found",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+            @ApiResponse(responseCode = "409", description = "Duplicate table number",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
+    })
+    public ResponseEntity<TableResponseDTO> createTable(
+            @Parameter(description = "ID of the branch", required = true)
+            @PathVariable Long branchId,
+            @Valid @RequestBody TableRequestDTO requestDTO) {
+
+        log.info("REST request to create table {} for branch {}", requestDTO.getTableNumber(), branchId);
+        TableResponseDTO response = tableService.createTable(branchId, requestDTO);
+
+        URI location = URI.create("/" + ApiConstants.APP_NAME + SECURE_API_VERSION + "/tables/" + response.getTableId());
+        return ResponseEntity.created(location).body(response);
+    }
+
+    @PutMapping(value = "/tables/{tableId}",
+            consumes = MediaType.APPLICATION_JSON_VALUE,
+            produces = MediaType.APPLICATION_JSON_VALUE)
+    @PreAuthorize("hasRole('ADMIN') or hasRole('MANAGER')")
+    @Operation(
+            summary = "Update a table",
+            description = "Updates table details and status. Requires ADMIN or MANAGER role.",
+            security = @SecurityRequirement(name = "bearerAuth")
+    )
+    public ResponseEntity<TableResponseDTO> updateTable(
+            @Parameter(description = "ID of the table", required = true)
+            @PathVariable Long tableId,
+            @Valid @RequestBody TableRequestDTO requestDTO) {
+
+        log.info("REST request to update table {}", tableId);
+        return ResponseEntity.ok(tableService.updateTable(tableId, requestDTO));
+    }
+
+    @DeleteMapping("/tables/{tableId}")
+    @PreAuthorize("hasRole('ADMIN')")
+    @ResponseStatus(HttpStatus.NO_CONTENT)
+    @Operation(
+            summary = "Delete a table",
+            description = "Soft deletes a table. Requires ADMIN role.",
+            security = @SecurityRequirement(name = "bearerAuth")
+    )
+    public ResponseEntity<Void> deleteTable(
+            @Parameter(description = "ID of the table", required = true)
+            @PathVariable Long tableId) {
+
+        log.info("REST request to delete table {}", tableId);
+        tableService.deleteTable(tableId);
+        return ResponseEntity.noContent().build();
+    }
+
+    @PatchMapping(value = "/tables/{tableId}/restore", produces = MediaType.APPLICATION_JSON_VALUE)
+    @PreAuthorize("hasRole('ADMIN')")
+    @Operation(
+            summary = "Restore a table",
+            description = "Restores a soft-deleted table. Requires ADMIN role.",
+            security = @SecurityRequirement(name = "bearerAuth")
+    )
+    public ResponseEntity<TableResponseDTO> restoreTable(
+            @Parameter(description = "ID of the table", required = true)
+            @PathVariable Long tableId) {
+
+        log.info("REST request to restore table {}", tableId);
+        return ResponseEntity.ok(tableService.restoreTable(tableId));
+    }
+}

--- a/RestroHub/src/main/java/com/restroly/qrmenu/table/controller/TableController.java
+++ b/RestroHub/src/main/java/com/restroly/qrmenu/table/controller/TableController.java
@@ -56,10 +56,10 @@ public class TableController {
     @PostMapping(value = "/branches/{branchId}/tables",
             consumes = MediaType.APPLICATION_JSON_VALUE,
             produces = MediaType.APPLICATION_JSON_VALUE)
-    @PreAuthorize("hasRole('ADMIN') or hasRole('MANAGER')")
+    @PreAuthorize("hasAnyRole('ADMIN', 'MANAGER', 'RESTAURANT_OWNER')")
     @Operation(
             summary = "Create a table",
-            description = "Creates a new table for a branch. Requires ADMIN or MANAGER role.",
+            description = "Creates a new table for a branch. Requires ADMIN, MANAGER, or RESTAURANT_OWNER role.",
             security = @SecurityRequirement(name = "bearerAuth")
     )
     @ApiResponses({
@@ -87,10 +87,10 @@ public class TableController {
     @PutMapping(value = "/tables/{tableId}",
             consumes = MediaType.APPLICATION_JSON_VALUE,
             produces = MediaType.APPLICATION_JSON_VALUE)
-    @PreAuthorize("hasRole('ADMIN') or hasRole('MANAGER')")
+    @PreAuthorize("hasAnyRole('ADMIN', 'MANAGER', 'RESTAURANT_OWNER')")
     @Operation(
             summary = "Update a table",
-            description = "Updates table details and status. Requires ADMIN or MANAGER role.",
+            description = "Updates table details and status. Requires ADMIN, MANAGER, or RESTAURANT_OWNER role.",
             security = @SecurityRequirement(name = "bearerAuth")
     )
     public ResponseEntity<TableResponseDTO> updateTable(
@@ -103,11 +103,11 @@ public class TableController {
     }
 
     @DeleteMapping("/tables/{tableId}")
-    @PreAuthorize("hasRole('ADMIN')")
+    @PreAuthorize("hasAnyRole('ADMIN', 'MANAGER', 'RESTAURANT_OWNER')")
     @ResponseStatus(HttpStatus.NO_CONTENT)
     @Operation(
             summary = "Delete a table",
-            description = "Soft deletes a table. Requires ADMIN role.",
+            description = "Soft deletes a table. Requires ADMIN, MANAGER, or RESTAURANT_OWNER role.",
             security = @SecurityRequirement(name = "bearerAuth")
     )
     public ResponseEntity<Void> deleteTable(
@@ -120,10 +120,10 @@ public class TableController {
     }
 
     @PatchMapping(value = "/tables/{tableId}/restore", produces = MediaType.APPLICATION_JSON_VALUE)
-    @PreAuthorize("hasRole('ADMIN')")
+    @PreAuthorize("hasAnyRole('ADMIN', 'MANAGER', 'RESTAURANT_OWNER')")
     @Operation(
             summary = "Restore a table",
-            description = "Restores a soft-deleted table. Requires ADMIN role.",
+            description = "Restores a soft-deleted table. Requires ADMIN, MANAGER, or RESTAURANT_OWNER role.",
             security = @SecurityRequirement(name = "bearerAuth")
     )
     public ResponseEntity<TableResponseDTO> restoreTable(

--- a/RestroHub/src/main/java/com/restroly/qrmenu/table/dto/TableRequestDTO.java
+++ b/RestroHub/src/main/java/com/restroly/qrmenu/table/dto/TableRequestDTO.java
@@ -1,0 +1,31 @@
+package com.restroly.qrmenu.table.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Pattern;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@Schema(description = "Table creation and update request payload")
+public class TableRequestDTO {
+
+    @NotNull(message = "Table number is required")
+    @Min(value = 1, message = "Table number must be greater than 0")
+    private Integer tableNumber;
+
+    @Min(value = 1, message = "Capacity must be greater than 0")
+    private Integer capacity;
+
+    @Pattern(regexp = "available|occupied|reserved",
+            message = "Status must be available, occupied, or reserved")
+    private String status;
+
+    private String qrCodeUrl;
+}

--- a/RestroHub/src/main/java/com/restroly/qrmenu/table/dto/TableRequestDTO.java
+++ b/RestroHub/src/main/java/com/restroly/qrmenu/table/dto/TableRequestDTO.java
@@ -23,7 +23,7 @@ public class TableRequestDTO {
     @Min(value = 1, message = "Capacity must be greater than 0")
     private Integer capacity;
 
-    @Pattern(regexp = "available|occupied|reserved",
+    @Pattern(regexp = "(?i)available|occupied|reserved",
             message = "Status must be available, occupied, or reserved")
     private String status;
 

--- a/RestroHub/src/main/java/com/restroly/qrmenu/table/dto/TableResponseDTO.java
+++ b/RestroHub/src/main/java/com/restroly/qrmenu/table/dto/TableResponseDTO.java
@@ -1,0 +1,32 @@
+package com.restroly.qrmenu.table.dto;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@Schema(description = "Table response payload")
+public class TableResponseDTO {
+
+    private Long tableId;
+    private Long branchId;
+    private Integer tableNumber;
+    private Integer capacity;
+    private String status;
+    private String qrCodeUrl;
+    private Boolean isActive;
+
+    @JsonFormat(pattern = "yyyy-MM-dd'T'HH:mm:ss")
+    private LocalDateTime createdDate;
+
+    @JsonFormat(pattern = "yyyy-MM-dd'T'HH:mm:ss")
+    private LocalDateTime updatedDate;
+}

--- a/RestroHub/src/main/java/com/restroly/qrmenu/table/entity/Tables.java
+++ b/RestroHub/src/main/java/com/restroly/qrmenu/table/entity/Tables.java
@@ -5,6 +5,8 @@ import com.restroly.qrmenu.branch.entity.Branch;
 import jakarta.persistence.*;
 import lombok.*;
 
+import java.time.LocalDateTime;
+
 @Entity
 @Table(name = "T_table_master")
 @Getter
@@ -26,6 +28,14 @@ public class Tables {
     @Column(name = "table_number", nullable = false)
     private Integer tableNumber;
 
+    @Column(name = "capacity", nullable = false)
+    @Builder.Default
+    private Integer capacity = 4;
+
+    @Column(name = "status", nullable = false, length = 20)
+    @Builder.Default
+    private String status = "available";
+
     @Column(name = "qr_code_url")
     private String qrCodeUrl;
 
@@ -33,4 +43,29 @@ public class Tables {
     @Builder.Default
     private Boolean isActive = true;
 
+    @Column(name = "created_date")
+    private LocalDateTime createdDate;
+
+    @Column(name = "updated_date")
+    private LocalDateTime updatedDate;
+
+    @PrePersist
+    protected void onCreate() {
+        createdDate = LocalDateTime.now();
+        updatedDate = LocalDateTime.now();
+        if (isActive == null) {
+            isActive = true;
+        }
+        if (capacity == null) {
+            capacity = 4;
+        }
+        if (status == null || status.isBlank()) {
+            status = "available";
+        }
+    }
+
+    @PreUpdate
+    protected void onUpdate() {
+        updatedDate = LocalDateTime.now();
+    }
 }

--- a/RestroHub/src/main/java/com/restroly/qrmenu/table/repository/TablesRepository.java
+++ b/RestroHub/src/main/java/com/restroly/qrmenu/table/repository/TablesRepository.java
@@ -17,5 +17,11 @@ public interface TablesRepository extends JpaRepository<Tables, Long> {
 
 	List<Tables> findByBranch_BranchId(Long branchId);
 
-	Tables findByTableNumber(Long tableNumber);
+	Optional<Tables> findByBranch_BranchIdAndTableNumber(Long branchId, Integer tableNumber);
+
+	boolean existsByBranch_BranchIdAndTableNumber(Long branchId, Integer tableNumber);
+
+	boolean existsByBranch_BranchIdAndTableNumberAndTableIdNot(Long branchId, Integer tableNumber, Long tableId);
+
+	Tables findByTableNumber(Integer tableNumber);
 }

--- a/RestroHub/src/main/java/com/restroly/qrmenu/table/repository/TablesRepository.java
+++ b/RestroHub/src/main/java/com/restroly/qrmenu/table/repository/TablesRepository.java
@@ -17,11 +17,12 @@ public interface TablesRepository extends JpaRepository<Tables, Long> {
 
 	List<Tables> findByBranch_BranchId(Long branchId);
 
-	Optional<Tables> findByBranch_BranchIdAndTableNumber(Long branchId, Integer tableNumber);
-
 	boolean existsByBranch_BranchIdAndTableNumber(Long branchId, Integer tableNumber);
 
 	boolean existsByBranch_BranchIdAndTableNumberAndTableIdNot(Long branchId, Integer tableNumber, Long tableId);
+
+	boolean existsByBranch_BranchIdAndTableNumberAndIsActiveTrueAndTableIdNot(
+			Long branchId, Integer tableNumber, Long tableId);
 
 	Tables findByTableNumber(Integer tableNumber);
 }

--- a/RestroHub/src/main/java/com/restroly/qrmenu/table/service/TableService.java
+++ b/RestroHub/src/main/java/com/restroly/qrmenu/table/service/TableService.java
@@ -1,0 +1,19 @@
+package com.restroly.qrmenu.table.service;
+
+import com.restroly.qrmenu.table.dto.TableRequestDTO;
+import com.restroly.qrmenu.table.dto.TableResponseDTO;
+
+import java.util.List;
+
+public interface TableService {
+
+    List<TableResponseDTO> getTablesByBranch(Long branchId);
+
+    TableResponseDTO createTable(Long branchId, TableRequestDTO requestDTO);
+
+    TableResponseDTO updateTable(Long tableId, TableRequestDTO requestDTO);
+
+    void deleteTable(Long tableId);
+
+    TableResponseDTO restoreTable(Long tableId);
+}

--- a/RestroHub/src/main/java/com/restroly/qrmenu/table/service/TableServiceImpl.java
+++ b/RestroHub/src/main/java/com/restroly/qrmenu/table/service/TableServiceImpl.java
@@ -73,7 +73,7 @@ public class TableServiceImpl implements TableService {
 
         table.setTableNumber(requestDTO.getTableNumber());
         table.setCapacity(requestDTO.getCapacity() != null ? requestDTO.getCapacity() : table.getCapacity());
-        table.setStatus(normalizeStatus(requestDTO.getStatus()));
+        table.setStatus(hasText(requestDTO.getStatus()) ? normalizeStatus(requestDTO.getStatus()) : table.getStatus());
         table.setQrCodeUrl(requestDTO.getQrCodeUrl());
 
         return toResponseDTO(tablesRepository.save(table));
@@ -95,11 +95,10 @@ public class TableServiceImpl implements TableService {
         Tables table = findTableOrThrow(tableId);
         Long branchId = table.getBranch().getBranchId();
 
-        tablesRepository.findByBranch_BranchIdAndTableNumber(branchId, table.getTableNumber())
-                .filter(existing -> !existing.getTableId().equals(tableId) && Boolean.TRUE.equals(existing.getIsActive()))
-                .ifPresent(existing -> {
-                    throw duplicateTableNumber(branchId, table.getTableNumber());
-                });
+        if (tablesRepository.existsByBranch_BranchIdAndTableNumberAndIsActiveTrueAndTableIdNot(
+                branchId, table.getTableNumber(), tableId)) {
+            throw duplicateTableNumber(branchId, table.getTableNumber());
+        }
 
         table.setIsActive(true);
         return toResponseDTO(tablesRepository.save(table));
@@ -123,6 +122,10 @@ public class TableServiceImpl implements TableService {
 
     private String normalizeStatus(String status) {
         return status == null || status.isBlank() ? "available" : status.toLowerCase();
+    }
+
+    private boolean hasText(String value) {
+        return value != null && !value.isBlank();
     }
 
     private TableResponseDTO toResponseDTO(Tables table) {

--- a/RestroHub/src/main/java/com/restroly/qrmenu/table/service/TableServiceImpl.java
+++ b/RestroHub/src/main/java/com/restroly/qrmenu/table/service/TableServiceImpl.java
@@ -1,0 +1,141 @@
+package com.restroly.qrmenu.table.service;
+
+import com.restroly.qrmenu.branch.entity.Branch;
+import com.restroly.qrmenu.branch.repository.BranchRepository;
+import com.restroly.qrmenu.common.exception.ResourceAlreadyExistsException;
+import com.restroly.qrmenu.common.exception.ResourceNotFoundException;
+import com.restroly.qrmenu.table.dto.TableRequestDTO;
+import com.restroly.qrmenu.table.dto.TableResponseDTO;
+import com.restroly.qrmenu.table.entity.Tables;
+import com.restroly.qrmenu.table.repository.TablesRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+@Transactional
+public class TableServiceImpl implements TableService {
+
+    private static final String TABLE_NOT_FOUND = "Table not found with id: %s";
+
+    private final TablesRepository tablesRepository;
+    private final BranchRepository branchRepository;
+
+    @Override
+    @Transactional(readOnly = true)
+    public List<TableResponseDTO> getTablesByBranch(Long branchId) {
+        validateBranchExists(branchId);
+        return tablesRepository.findByBranch_BranchId(branchId)
+                .stream()
+                .map(this::toResponseDTO)
+                .toList();
+    }
+
+    @Override
+    public TableResponseDTO createTable(Long branchId, TableRequestDTO requestDTO) {
+        log.info("Creating table {} for branch {}", requestDTO.getTableNumber(), branchId);
+
+        Branch branch = branchRepository.findByBranchIdAndIsDeleteFalse(branchId)
+                .orElseThrow(() -> new ResourceNotFoundException("Branch not found with id: " + branchId));
+
+        if (tablesRepository.existsByBranch_BranchIdAndTableNumber(branchId, requestDTO.getTableNumber())) {
+            throw duplicateTableNumber(branchId, requestDTO.getTableNumber());
+        }
+
+        Tables table = Tables.builder()
+                .branch(branch)
+                .tableNumber(requestDTO.getTableNumber())
+                .capacity(requestDTO.getCapacity() != null ? requestDTO.getCapacity() : 4)
+                .status(normalizeStatus(requestDTO.getStatus()))
+                .qrCodeUrl(requestDTO.getQrCodeUrl())
+                .isActive(true)
+                .build();
+
+        return toResponseDTO(tablesRepository.save(table));
+    }
+
+    @Override
+    public TableResponseDTO updateTable(Long tableId, TableRequestDTO requestDTO) {
+        log.info("Updating table {}", tableId);
+
+        Tables table = findTableOrThrow(tableId);
+        Long branchId = table.getBranch().getBranchId();
+
+        if (tablesRepository.existsByBranch_BranchIdAndTableNumberAndTableIdNot(
+                branchId, requestDTO.getTableNumber(), tableId)) {
+            throw duplicateTableNumber(branchId, requestDTO.getTableNumber());
+        }
+
+        table.setTableNumber(requestDTO.getTableNumber());
+        table.setCapacity(requestDTO.getCapacity() != null ? requestDTO.getCapacity() : table.getCapacity());
+        table.setStatus(normalizeStatus(requestDTO.getStatus()));
+        table.setQrCodeUrl(requestDTO.getQrCodeUrl());
+
+        return toResponseDTO(tablesRepository.save(table));
+    }
+
+    @Override
+    public void deleteTable(Long tableId) {
+        log.info("Soft deleting table {}", tableId);
+
+        Tables table = findTableOrThrow(tableId);
+        table.setIsActive(false);
+        tablesRepository.save(table);
+    }
+
+    @Override
+    public TableResponseDTO restoreTable(Long tableId) {
+        log.info("Restoring table {}", tableId);
+
+        Tables table = findTableOrThrow(tableId);
+        Long branchId = table.getBranch().getBranchId();
+
+        tablesRepository.findByBranch_BranchIdAndTableNumber(branchId, table.getTableNumber())
+                .filter(existing -> !existing.getTableId().equals(tableId) && Boolean.TRUE.equals(existing.getIsActive()))
+                .ifPresent(existing -> {
+                    throw duplicateTableNumber(branchId, table.getTableNumber());
+                });
+
+        table.setIsActive(true);
+        return toResponseDTO(tablesRepository.save(table));
+    }
+
+    private void validateBranchExists(Long branchId) {
+        if (branchRepository.findByBranchIdAndIsDeleteFalse(branchId).isEmpty()) {
+            throw new ResourceNotFoundException("Branch not found with id: " + branchId);
+        }
+    }
+
+    private Tables findTableOrThrow(Long tableId) {
+        return tablesRepository.findById(tableId)
+                .orElseThrow(() -> new ResourceNotFoundException(String.format(TABLE_NOT_FOUND, tableId)));
+    }
+
+    private ResourceAlreadyExistsException duplicateTableNumber(Long branchId, Integer tableNumber) {
+        return new ResourceAlreadyExistsException(
+                "Table number " + tableNumber + " already exists for branch id: " + branchId);
+    }
+
+    private String normalizeStatus(String status) {
+        return status == null || status.isBlank() ? "available" : status.toLowerCase();
+    }
+
+    private TableResponseDTO toResponseDTO(Tables table) {
+        return TableResponseDTO.builder()
+                .tableId(table.getTableId())
+                .branchId(table.getBranch() != null ? table.getBranch().getBranchId() : null)
+                .tableNumber(table.getTableNumber())
+                .capacity(table.getCapacity())
+                .status(table.getStatus())
+                .qrCodeUrl(table.getQrCodeUrl())
+                .isActive(table.getIsActive())
+                .createdDate(table.getCreatedDate())
+                .updatedDate(table.getUpdatedDate())
+                .build();
+    }
+}

--- a/RestroHub/src/test/java/com/restroly/qrmenu/table/service/TableServiceImplTest.java
+++ b/RestroHub/src/test/java/com/restroly/qrmenu/table/service/TableServiceImplTest.java
@@ -1,0 +1,270 @@
+package com.restroly.qrmenu.table.service;
+
+import com.restroly.qrmenu.branch.entity.Branch;
+import com.restroly.qrmenu.branch.repository.BranchRepository;
+import com.restroly.qrmenu.common.exception.ResourceAlreadyExistsException;
+import com.restroly.qrmenu.common.exception.ResourceNotFoundException;
+import com.restroly.qrmenu.table.dto.TableRequestDTO;
+import com.restroly.qrmenu.table.dto.TableResponseDTO;
+import com.restroly.qrmenu.table.entity.Tables;
+import com.restroly.qrmenu.table.repository.TablesRepository;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.List;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class TableServiceImplTest {
+
+    @Mock
+    private TablesRepository tablesRepository;
+
+    @Mock
+    private BranchRepository branchRepository;
+
+    @InjectMocks
+    private TableServiceImpl tableService;
+
+    @Test
+    void createTableShouldPersistBranchScopedTable() {
+        Branch branch = Branch.builder().branchId(1L).build();
+        TableRequestDTO request = TableRequestDTO.builder()
+                .tableNumber(5)
+                .capacity(4)
+                .status("available")
+                .build();
+
+        when(branchRepository.findByBranchIdAndIsDeleteFalse(1L)).thenReturn(Optional.of(branch));
+        when(tablesRepository.existsByBranch_BranchIdAndTableNumber(1L, 5)).thenReturn(false);
+        when(tablesRepository.save(any(Tables.class))).thenAnswer(invocation -> {
+            Tables table = invocation.getArgument(0);
+            table.setTableId(10L);
+            return table;
+        });
+
+        TableResponseDTO response = tableService.createTable(1L, request);
+
+        assertEquals(10L, response.getTableId());
+        assertEquals(1L, response.getBranchId());
+        assertEquals(5, response.getTableNumber());
+        assertTrue(response.getIsActive());
+        verify(tablesRepository).save(any(Tables.class));
+    }
+
+    @Test
+    void createTableShouldApplyDefaultsWhenOptionalFieldsAreMissing() {
+        Branch branch = Branch.builder().branchId(1L).build();
+        TableRequestDTO request = TableRequestDTO.builder()
+                .tableNumber(7)
+                .build();
+
+        when(branchRepository.findByBranchIdAndIsDeleteFalse(1L)).thenReturn(Optional.of(branch));
+        when(tablesRepository.existsByBranch_BranchIdAndTableNumber(1L, 7)).thenReturn(false);
+        when(tablesRepository.save(any(Tables.class))).thenAnswer(invocation -> {
+            Tables table = invocation.getArgument(0);
+            table.setTableId(11L);
+            return table;
+        });
+
+        TableResponseDTO response = tableService.createTable(1L, request);
+
+        assertEquals(4, response.getCapacity());
+        assertEquals("available", response.getStatus());
+        assertTrue(response.getIsActive());
+    }
+
+    @Test
+    void createTableShouldRejectMissingBranch() {
+        TableRequestDTO request = TableRequestDTO.builder().tableNumber(5).build();
+
+        when(branchRepository.findByBranchIdAndIsDeleteFalse(99L)).thenReturn(Optional.empty());
+
+        assertThrows(ResourceNotFoundException.class, () -> tableService.createTable(99L, request));
+        verify(tablesRepository, never()).save(any(Tables.class));
+    }
+
+    @Test
+    void createTableShouldRejectDuplicateTableNumberInBranch() {
+        TableRequestDTO request = TableRequestDTO.builder().tableNumber(5).build();
+
+        when(branchRepository.findByBranchIdAndIsDeleteFalse(1L))
+                .thenReturn(Optional.of(Branch.builder().branchId(1L).build()));
+        when(tablesRepository.existsByBranch_BranchIdAndTableNumber(1L, 5)).thenReturn(true);
+
+        assertThrows(ResourceAlreadyExistsException.class, () -> tableService.createTable(1L, request));
+        verify(tablesRepository, never()).save(any(Tables.class));
+    }
+
+    @Test
+    void getTablesByBranchShouldRejectMissingBranch() {
+        when(branchRepository.findByBranchIdAndIsDeleteFalse(99L)).thenReturn(Optional.empty());
+
+        assertThrows(ResourceNotFoundException.class, () -> tableService.getTablesByBranch(99L));
+        verify(tablesRepository, never()).findByBranch_BranchId(99L);
+    }
+
+    @Test
+    void deleteTableShouldDeactivateTable() {
+        Tables table = Tables.builder()
+                .tableId(10L)
+                .branch(Branch.builder().branchId(1L).build())
+                .tableNumber(5)
+                .isActive(true)
+                .build();
+
+        when(tablesRepository.findById(10L)).thenReturn(Optional.of(table));
+        when(tablesRepository.save(table)).thenReturn(table);
+
+        tableService.deleteTable(10L);
+
+        assertFalse(table.getIsActive());
+        verify(tablesRepository).save(table);
+    }
+
+    @Test
+    void deleteTableShouldRejectMissingTable() {
+        when(tablesRepository.findById(99L)).thenReturn(Optional.empty());
+
+        assertThrows(ResourceNotFoundException.class, () -> tableService.deleteTable(99L));
+        verify(tablesRepository, never()).save(any(Tables.class));
+    }
+
+    @Test
+    void updateTableShouldChangeDetailsAndKeepExistingCapacityWhenMissing() {
+        Branch branch = Branch.builder().branchId(1L).build();
+        Tables table = Tables.builder()
+                .tableId(10L)
+                .branch(branch)
+                .tableNumber(5)
+                .capacity(6)
+                .status("reserved")
+                .isActive(true)
+                .build();
+        TableRequestDTO request = TableRequestDTO.builder()
+                .tableNumber(8)
+                .status("occupied")
+                .qrCodeUrl("https://example.com/qr/table-8")
+                .build();
+
+        when(tablesRepository.findById(10L)).thenReturn(Optional.of(table));
+        when(tablesRepository.existsByBranch_BranchIdAndTableNumberAndTableIdNot(1L, 8, 10L)).thenReturn(false);
+        when(tablesRepository.save(table)).thenReturn(table);
+
+        TableResponseDTO response = tableService.updateTable(10L, request);
+
+        assertEquals(8, response.getTableNumber());
+        assertEquals(6, response.getCapacity());
+        assertEquals("occupied", response.getStatus());
+        assertEquals("https://example.com/qr/table-8", response.getQrCodeUrl());
+    }
+
+    @Test
+    void updateTableShouldRejectDuplicateTableNumberInBranch() {
+        Branch branch = Branch.builder().branchId(1L).build();
+        Tables table = Tables.builder()
+                .tableId(10L)
+                .branch(branch)
+                .tableNumber(5)
+                .isActive(true)
+                .build();
+        TableRequestDTO request = TableRequestDTO.builder().tableNumber(8).build();
+
+        when(tablesRepository.findById(10L)).thenReturn(Optional.of(table));
+        when(tablesRepository.existsByBranch_BranchIdAndTableNumberAndTableIdNot(1L, 8, 10L)).thenReturn(true);
+
+        assertThrows(ResourceAlreadyExistsException.class, () -> tableService.updateTable(10L, request));
+        verify(tablesRepository, never()).save(any(Tables.class));
+    }
+
+    @Test
+    void updateTableShouldRejectMissingTable() {
+        TableRequestDTO request = TableRequestDTO.builder().tableNumber(8).build();
+
+        when(tablesRepository.findById(99L)).thenReturn(Optional.empty());
+
+        assertThrows(ResourceNotFoundException.class, () -> tableService.updateTable(99L, request));
+    }
+
+    @Test
+    void restoreTableShouldReactivateTable() {
+        Tables table = Tables.builder()
+                .tableId(10L)
+                .branch(Branch.builder().branchId(1L).build())
+                .tableNumber(5)
+                .isActive(false)
+                .build();
+
+        when(tablesRepository.findById(10L)).thenReturn(Optional.of(table));
+        when(tablesRepository.findByBranch_BranchIdAndTableNumber(1L, 5)).thenReturn(Optional.of(table));
+        when(tablesRepository.save(table)).thenReturn(table);
+
+        TableResponseDTO response = tableService.restoreTable(10L);
+
+        assertTrue(response.getIsActive());
+        verify(tablesRepository).save(table);
+    }
+
+    @Test
+    void restoreTableShouldRejectMissingTable() {
+        when(tablesRepository.findById(99L)).thenReturn(Optional.empty());
+
+        assertThrows(ResourceNotFoundException.class, () -> tableService.restoreTable(99L));
+        verify(tablesRepository, never()).save(any(Tables.class));
+    }
+
+    @Test
+    void restoreTableShouldRejectActiveDuplicateTableNumber() {
+        Branch branch = Branch.builder().branchId(1L).build();
+        Tables inactiveTable = Tables.builder()
+                .tableId(10L)
+                .branch(branch)
+                .tableNumber(5)
+                .isActive(false)
+                .build();
+        Tables activeDuplicate = Tables.builder()
+                .tableId(11L)
+                .branch(branch)
+                .tableNumber(5)
+                .isActive(true)
+                .build();
+
+        when(tablesRepository.findById(10L)).thenReturn(Optional.of(inactiveTable));
+        when(tablesRepository.findByBranch_BranchIdAndTableNumber(1L, 5)).thenReturn(Optional.of(activeDuplicate));
+
+        assertThrows(ResourceAlreadyExistsException.class, () -> tableService.restoreTable(10L));
+        verify(tablesRepository, never()).save(any(Tables.class));
+    }
+
+    @Test
+    void getTablesByBranchShouldReturnAllBranchTables() {
+        Branch branch = Branch.builder().branchId(1L).build();
+        Tables activeTable = Tables.builder()
+                .tableId(10L)
+                .branch(branch)
+                .tableNumber(1)
+                .isActive(true)
+                .build();
+        Tables inactiveTable = Tables.builder()
+                .tableId(11L)
+                .branch(branch)
+                .tableNumber(2)
+                .isActive(false)
+                .build();
+
+        when(branchRepository.findByBranchIdAndIsDeleteFalse(1L)).thenReturn(Optional.of(branch));
+        when(tablesRepository.findByBranch_BranchId(1L)).thenReturn(List.of(activeTable, inactiveTable));
+
+        List<TableResponseDTO> response = tableService.getTablesByBranch(1L);
+
+        assertEquals(2, response.size());
+        assertFalse(response.get(1).getIsActive());
+    }
+}

--- a/RestroHub/src/test/java/com/restroly/qrmenu/table/service/TableServiceImplTest.java
+++ b/RestroHub/src/test/java/com/restroly/qrmenu/table/service/TableServiceImplTest.java
@@ -167,6 +167,32 @@ class TableServiceImplTest {
     }
 
     @Test
+    void updateTableShouldKeepExistingStatusWhenMissing() {
+        Branch branch = Branch.builder().branchId(1L).build();
+        Tables table = Tables.builder()
+                .tableId(10L)
+                .branch(branch)
+                .tableNumber(5)
+                .capacity(6)
+                .status("reserved")
+                .isActive(true)
+                .build();
+        TableRequestDTO request = TableRequestDTO.builder()
+                .tableNumber(5)
+                .capacity(8)
+                .build();
+
+        when(tablesRepository.findById(10L)).thenReturn(Optional.of(table));
+        when(tablesRepository.existsByBranch_BranchIdAndTableNumberAndTableIdNot(1L, 5, 10L)).thenReturn(false);
+        when(tablesRepository.save(table)).thenReturn(table);
+
+        TableResponseDTO response = tableService.updateTable(10L, request);
+
+        assertEquals(8, response.getCapacity());
+        assertEquals("reserved", response.getStatus());
+    }
+
+    @Test
     void updateTableShouldRejectDuplicateTableNumberInBranch() {
         Branch branch = Branch.builder().branchId(1L).build();
         Tables table = Tables.builder()
@@ -203,7 +229,8 @@ class TableServiceImplTest {
                 .build();
 
         when(tablesRepository.findById(10L)).thenReturn(Optional.of(table));
-        when(tablesRepository.findByBranch_BranchIdAndTableNumber(1L, 5)).thenReturn(Optional.of(table));
+        when(tablesRepository.existsByBranch_BranchIdAndTableNumberAndIsActiveTrueAndTableIdNot(1L, 5, 10L))
+                .thenReturn(false);
         when(tablesRepository.save(table)).thenReturn(table);
 
         TableResponseDTO response = tableService.restoreTable(10L);
@@ -229,15 +256,9 @@ class TableServiceImplTest {
                 .tableNumber(5)
                 .isActive(false)
                 .build();
-        Tables activeDuplicate = Tables.builder()
-                .tableId(11L)
-                .branch(branch)
-                .tableNumber(5)
-                .isActive(true)
-                .build();
-
         when(tablesRepository.findById(10L)).thenReturn(Optional.of(inactiveTable));
-        when(tablesRepository.findByBranch_BranchIdAndTableNumber(1L, 5)).thenReturn(Optional.of(activeDuplicate));
+        when(tablesRepository.existsByBranch_BranchIdAndTableNumberAndIsActiveTrueAndTableIdNot(1L, 5, 10L))
+                .thenReturn(true);
 
         assertThrows(ResourceAlreadyExistsException.class, () -> tableService.restoreTable(10L));
         verify(tablesRepository, never()).save(any(Tables.class));


### PR DESCRIPTION
## Issue Link
Closes #219

## Changes Made
- Added backend table DTOs, service, and controller for branch-specific table management.
- Added APIs to fetch, create, update, soft delete, and restore tables.
- Added duplicate table number validation within the same branch.
- Extended table persistence with capacity, status, and timestamps.
- Connected Admin Tables UI to real backend APIs.
- Updated add/edit/delete/restore table workflows.
- Updated QR preview URLs to use persisted table IDs and numbers.
- Added backend service tests for success paths and edge cases.

## Type of Change
- [x] New feature
- [x] Bug fix
- [ ] Documentation update
- [ ] Code refactor

## Testing Performed

### Backend Testing
- [x] Added service tests for table create/update/delete/restore workflows.
- [x] Added edge-case tests for duplicate table numbers, missing branch/table, default values, and restore conflicts.
- [ ] Unit tests passed locally

Note: Backend tests could not be executed locally because JAVA_HOME is invalid and no Java executable is available on PATH.

### Frontend Testing
- [x] Production build passed with `npm.cmd run build`.
- [x] Admin Tables UI now fetches and mutates real backend data.
- [x] QR preview uses persisted table ID and table number.

Note: `npm.cmd run lint` could not run because ESLint v9 requires `eslint.config.js`, which is not present on this branch.

## Additional Notes
- `git diff --check` passed.
- Vite build completed successfully with existing bundle-size warnings.