### PR TITLE
Fix: Payment Verification Error Handling

### DIFF
--- a/RestroHub/src/main/java/com/restroly/qrmenu/payment/exception/PaymentNotFoundException.java
+++ b/RestroHub/src/main/java/com/restroly/qrmenu/payment/exception/PaymentNotFoundException.java
@@ -1,6 +1,7 @@
 package com.restroly.qrmenu.payment.exception;
+import com.restroly.qrmenu.exception.ResourceNotFoundException;
 
-public class PaymentNotFoundException extends RuntimeException {
+public class PaymentNotFoundException extends ResourceNotFoundException {
     public PaymentNotFoundException(String message) {
         super(message);
     }

--- a/RestroHub/src/main/java/com/restroly/qrmenu/payment/exception/PaymentNotFoundException.java
+++ b/RestroHub/src/main/java/com/restroly/qrmenu/payment/exception/PaymentNotFoundException.java
@@ -1,0 +1,8 @@
+package com.restroly.qrmenu.payment.exception;
+
+public class PaymentNotFoundException extends RuntimeException {
+    public PaymentNotFoundException(String message) {
+        super(message);
+    }
+}
+

--- a/RestroHub/src/main/java/com/restroly/qrmenu/payment/service/PaymentServiceImpl.java
+++ b/RestroHub/src/main/java/com/restroly/qrmenu/payment/service/PaymentServiceImpl.java
@@ -110,7 +110,7 @@ public class PaymentServiceImpl implements PaymentService {
         
         PaymentVerification entity = verificationRepository.findByPaymentId(paymentId)
                 .orElseThrow(() ->{
-                    log.warn("PaymentId: {} not found in database",paymentId);
+                    log.warn("PaymentId: {} not found in database", paymentId);
                     return new PaymentNotFoundException("Payment record not found for paymentId: " + paymentId);
                 });
 
@@ -126,7 +126,7 @@ public class PaymentServiceImpl implements PaymentService {
         
         PaymentVerification entity = verificationRepository.findByPaymentId(paymentId)
                 .orElseThrow(() -> {
-                    log.warn("PaymentId: {} not found in database",paymentId);
+                    log.warn("PaymentId: {} not found in database", paymentId);
                     return new PaymentNotFoundException("Payment record not found for paymentId: " + paymentId);
                 });
 

--- a/RestroHub/src/main/java/com/restroly/qrmenu/payment/service/PaymentServiceImpl.java
+++ b/RestroHub/src/main/java/com/restroly/qrmenu/payment/service/PaymentServiceImpl.java
@@ -7,6 +7,7 @@ import com.google.zxing.common.BitMatrix;
 import com.google.zxing.qrcode.QRCodeWriter;
 import com.restroly.qrmenu.payment.entity.PaymentStatus;
 import com.restroly.qrmenu.payment.entity.PaymentVerification;
+import com.restroly.qrmenu.payment.exception.PaymentNotFoundException;
 import com.restroly.qrmenu.payment.repository.PaymentVerificationRepository;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
@@ -106,19 +107,33 @@ public class PaymentServiceImpl implements PaymentService {
 
     public void markPaymentAsVerified(String paymentId, String transactionId) {
         log.info("Marking paymentId: {} as verified with transactionId: {}", paymentId, transactionId);
-        verificationRepository.findByPaymentId(paymentId).ifPresent(entity -> {
-            entity.setStatus(PaymentStatus.SUCCESS);
-            entity.setTransactionId(transactionId);
-            verificationRepository.save(entity);
-        });
+        
+        PaymentVerification entity = verificationRepository.findByPaymentId(paymentId)
+                .orElseThrow(() ->{
+                    log.warn("PaymentId: {} not found in database",paymentId);
+                    return new PaymentNotFoundException("Payment record not found for paymentId: " + paymentId);
+                });
+
+        entity.setStatus(PaymentStatus.SUCCESS);
+        entity.setTransactionId(transactionId);
+        verificationRepository.save(entity);
+
+        log.info("PaymentId: {} marked as SUCCESS with transactionId: {}", paymentId, transactionId);
     }
 
     public void markPaymentAsCancelled(String paymentId) {
         log.info("Marking paymentId: {} as cancelled", paymentId);
-        verificationRepository.findByPaymentId(paymentId).ifPresent(entity -> {
-            entity.setStatus(PaymentStatus.CANCELLED);
-            verificationRepository.save(entity);
-        });
+        
+        PaymentVerification entity = verificationRepository.findByPaymentId(paymentId)
+                .orElseThrow(() -> {
+                    log.warn("PaymentId: {} not found in database",paymentId);
+                    return new PaymentNotFoundException("Payment record not found for paymentId: " + paymentId);
+                });
+
+        entity.setStatus(PaymentStatus.CANCELLED);
+        verificationRepository.save(entity);
+
+        log.info("PaymentId: {} marked as cancelled", paymentId);
     }
 
     @Override


### PR DESCRIPTION
### Summary
This PR fixes the issue in `PaymentServiceImpl` where `markPaymentAsVerified` and `markPaymentAsCancelled` silently ignored invalid `paymentId` values.  
Now, both methods throw `PaymentNotFoundException` when the payment record is missing.

### Changes
- Replaced `ifPresent` with `orElseThrow` in both methods
- Added warning logs when paymentId is not found
- Introduced `PaymentNotFoundException` for clear error reporting
- Ensured success logs confirm updates when records are found
### Issue Reference
Fixes: #223
