### PR TITLE
fix(ui): replace browser alerts with toast notifications

### DIFF
--- a/RestroHub-FrontEnd/src/components/admin/menu/menuCard/MenusGrid.jsx
+++ b/RestroHub-FrontEnd/src/components/admin/menu/menuCard/MenusGrid.jsx
@@ -34,6 +34,7 @@ import {
 import { Dialog } from '@headlessui/react';
 import api from "@services/common/api";
 import AdminSkeleton from '../../AdminSkeleton';
+import toast from 'react-hot-toast';
 
 // ============================================
 // CONSTANTS
@@ -1004,7 +1005,9 @@ const MenusGrid = forwardRef(({ onEditMenu, onCreateMenu }, ref) => {
       setMenus((prev) => prev.filter((m) => m.menuId !== menuId));
     } catch (err) {
       console.error('Failed to delete menu:', err.response?.data || err);
-      alert(err.response?.data?.message || 'Failed to delete menu');
+      toast.error(
+        err.response?.data?.message || 'Failed to delete menu'  // Fallback message
+      );
     } finally {
       setDeletingId(null);
     }

--- a/RestroHub-FrontEnd/src/components/admin/store/branch/BranchesGrid.jsx
+++ b/RestroHub-FrontEnd/src/components/admin/store/branch/BranchesGrid.jsx
@@ -3,6 +3,7 @@ import { RefreshCw, AlertCircle, Building2 } from 'lucide-react';
 import api from '@services/common/api';
 import BranchCard from './BranchCard';
 import AdminSkeleton from '../../AdminSkeleton';
+import toast from 'react-hot-toast';
 
 // ============================================
 // MAIN
@@ -61,7 +62,9 @@ const BranchesGrid = forwardRef(({ onEdit, onCountChange, restaurantId }, ref) =
       onCountChange?.((prev) => prev - 1);
     } catch (err) {
       console.error('Delete failed:', err);
-      alert('Failed to delete branch');
+      toast.error(
+        err.response?.data?.message || 'Failed to delete branch'  // Fallback message
+      )
     }
   };
 
@@ -72,7 +75,9 @@ const BranchesGrid = forwardRef(({ onEdit, onCountChange, restaurantId }, ref) =
       fetchBranches();
     } catch (err) {
       console.error('Restore failed:', err);
-      alert('Failed to restore branch');
+      toast.error(
+        err.response?.data?.message || 'Failed to restore branch'  // Fallback message
+      );
     }
   };
 


### PR DESCRIPTION
# Closes #227

## Why this change?

The project already used `react-hot-toast` in several places, but a few admin workflows were still showing browser `alert()` dialogs when an action failed, this created an inconsistent user experience compared to the rest of the application.

This PR replaces those remaining alerts with toast notifications using the existing notification setup.

## Changes made

- Replaced browser `alert()` calls with `toast.error()` notifications
- Updated menu-related error handling in `MenusGrid.jsx`
- Updated branch delete/restore error handling in `BranchesGrid.jsx`
- Reused the existing `react-hot-toast` implementation already used across the project
- Preserved existing backend error messages where available

## Files updated

- `src/components/admin/menu/menuCard/MenusGrid.jsx`
- `src/components/admin/store/branch/BranchesGrid.jsx`

## Testing

- Verified frontend compiles successfully after the changes
- Verified affected admin pages load correctly
- Confirmed all remaining `alert()` usages related to this issue have been removed

## User-facing impact

Users will now see consistent toast notifications instead of browser alert popups when menu or branch actions failures