### PR TITLE
refactor(subscription): externalize status values to application.properties

### DIFF
--- a/RestroHub/src/main/java/com/restroly/qrmenu/subscription/service/impl/SubscriptionServiceImpl.java
+++ b/RestroHub/src/main/java/com/restroly/qrmenu/subscription/service/impl/SubscriptionServiceImpl.java
@@ -7,6 +7,7 @@ import com.restroly.qrmenu.subscription.entity.*;
 import com.restroly.qrmenu.subscription.repository.*;
 import com.restroly.qrmenu.subscription.service.SubscriptionService;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -18,6 +19,15 @@ import java.util.stream.Collectors;
 
 @Service
 public class SubscriptionServiceImpl implements SubscriptionService {
+
+    @Value("${subscription.status.active}")
+    private String STATUS_ACTIVE;
+
+    @Value("${subscription.status.cancelled}")
+    private String STATUS_CANCELLED;
+
+    @Value("${subscription.status.expired}")
+    private String STATUS_EXPIRED;
 
     @Autowired
     private SubscriptionPlanRepository planRepository;
@@ -126,7 +136,7 @@ public class SubscriptionServiceImpl implements SubscriptionService {
         Optional<RestaurantSubscription> existingActive = restaurantSubscriptionRepository.findActiveSubscriptionByRestaurantId(restaurantId);
         if (existingActive.isPresent()) {
             RestaurantSubscription activeSub = existingActive.get();
-            activeSub.setStatus("CANCELLED");
+            activeSub.setStatus(STATUS_CANCELLED);
             activeSub.setEndDate(LocalDateTime.now());
             restaurantSubscriptionRepository.save(activeSub);
         }
@@ -139,7 +149,7 @@ public class SubscriptionServiceImpl implements SubscriptionService {
                 .plan(plan)
                 .startDate(startDate)
                 .endDate(endDate)
-                .status("ACTIVE")
+                .status(STATUS_ACTIVE)
                 .isAutoRenew(request.getIsAutoRenew() != null ? request.getIsAutoRenew() : true)
                 .build();
 

--- a/RestroHub/src/main/resources/application-dev.properties
+++ b/RestroHub/src/main/resources/application-dev.properties
@@ -75,3 +75,10 @@ cloudinary.api-secret=${CLOUDINARY_API_SECRET:test}
 # Service Requests Configuration
 # ===============================
 service.request.types=CALL_WAITER,REQUEST_BILL
+
+# ===============================
+# Subscription Status
+# ===============================
+subscription.status.active=ACTIVE
+subscription.status.cancelled=CANCELLED
+subscription.status.expired=EXPIRED

--- a/RestroHub/src/main/resources/application-prod.properties
+++ b/RestroHub/src/main/resources/application-prod.properties
@@ -49,3 +49,11 @@ server.ssl.key-store-type=PKCS12
 logging.level.root=WARN
 logging.level.com.restroly=INFO
 logging.level.org.springframework.security=WARN
+
+
+# ===============================
+# Subscription Status
+# ===============================
+subscription.status.active=ACTIVE
+subscription.status.cancelled=CANCELLED
+subscription.status.expired=EXPIRED

--- a/RestroHub/src/main/resources/application-test.properties
+++ b/RestroHub/src/main/resources/application-test.properties
@@ -36,3 +36,11 @@ cloudinary.api-secret=test-api-secret
 # ===============================
 logging.level.com.restroly=DEBUG
 logging.level.org.springframework.security=DEBUG
+
+
+# ===============================
+# Subscription Status
+# ===============================
+subscription.status.active=ACTIVE
+subscription.status.cancelled=CANCELLED
+subscription.status.expired=EXPIRED

--- a/RestroHub/src/main/resources/application.properties
+++ b/RestroHub/src/main/resources/application.properties
@@ -136,3 +136,11 @@ spring.servlet.multipart.max-request-size=10MB
 # Service Requests Configuration
 # ===============================
 service.request.types=CALL_WAITER,REQUEST_BILL
+
+# ===============================
+# Subscription Status
+# ===============================
+subscription.status.active=ACTIVE
+subscription.status.cancelled=CANCELLED
+subscription.status.expired=EXPIRED
+


### PR DESCRIPTION
This PR addresses the issue of hardcoded subscription status values in SubscriptionServiceImpl.

- Removed hardcoded "ACTIVE" and "CANCELLED" strings in SubscriptionServiceImpl
- Added subscription status values in application.properties files
- Injected values using @Value for dynamic loading
- Ensures easier maintenance and consistent status management across environments
- Implemented as per @rdodiya  advice to avoid hardcoding enums and keep statuses flexible

By externalizing these values, future status changes can be managed through configuration without requiring code modifications.

Close Issue #235 