### PR TITLE
fix: align ForgotPassword password validation with Login password policy

### DIFF
--- a/RestroHub-FrontEnd/src/pages/public/ForgotPassword.jsx
+++ b/RestroHub-FrontEnd/src/pages/public/ForgotPassword.jsx
@@ -20,8 +20,11 @@ const resetPasswordSchema = Yup.object({
     .max(64, "Reset code is too long")
     .required("Reset code is required"),
   newPassword: Yup.string()
-    .min(6, "Password must be at least 6 characters")
-    .required("New password is required"),
+    .required("New password is required")
+    .matches(
+      /^(?=.*[a-z])(?=.*[A-Z])(?=.*\d)(?=.*[!@#$%^&*()_+\-=[\]{};':"\\|,.<>\/?`~]).{8,}$/,
+      "Password must be at least 8 characters and include uppercase, lowercase, number, and special character"
+    ),
   confirmPassword: Yup.string()
     .oneOf([Yup.ref("newPassword"), null], "Passwords must match")
     .required("Confirm password is required"),


### PR DESCRIPTION
Closes  #239

## What was the problem?

The Login page enforced a strong password policy requiring:

* Minimum 8 characters
* Uppercase letter
* Lowercase letter
* Number
* Special character

However, ForgotPassword.jsx only validated passwords with a minimum length of 6 characters. This allowed users to reset their password to a weak value that would later be rejected by the Login form.

## How was it solved?

* Updated the resetPasswordSchema in ForgotPassword.jsx.
* Matched the validation rules used in Login.jsx.
* Ensured password requirements remain consistent across authentication workflows.

## Impact

* Prevents users from creating passwords that cannot be used during login.
* Improves authentication consistency.
* Reduces confusion during password reset.

## Checklist

* Updated reset password validation schema.
* Matched Login page password rules.
* Tested password reset workflow.
* Followed CONTRIBUTING.md guidelines.
