### PR TITLE
fix: redirect user based on role after login instead of hardcoding admin dashboard

### DIFF
--- a/RestroHub-FrontEnd/src/pages/public/Login.jsx
+++ b/RestroHub-FrontEnd/src/pages/public/Login.jsx
@@ -180,7 +180,8 @@ const Login = () => {
 
           toast.success("Login successful!");
 
-          navigate("/admin/dashboard");
+          const redirectPath = roles && roles.includes("ADMIN") ? "/admin/dashboard" : "/";
+          navigate(redirectPath);
         } else {
           toast.error(result.message || "Login failed");
         }
@@ -215,7 +216,8 @@ const handleGoogleLogin = async (credentialResponse) => {
 
       toast.success("Google login successful!");
 
-      navigate("/admin/dashboard");
+      const redirectPath = roles && roles.includes("ADMIN") ? "/admin/dashboard" : "/";
+          navigate(redirectPath);
     } else {
       toast.error(result.message || "Google login failed");
     }


### PR DESCRIPTION
Closes #240

## What was the problem?

After successful authentication, both regular login and Google login flows redirected users to:

/admin/dashboard

This redirect was hardcoded and ignored the role information returned by the authentication response. As a result, non-admin users were incorrectly routed to the admin dashboard.

## How was it solved?

* Removed hardcoded navigation logic.
* Added role-based redirect handling using the roles returned by the API.
* Ensured users are redirected to the appropriate destination based on their assigned role.

## Impact

* Prevents unauthorized navigation to admin views.
* Improves user experience after login.
* Aligns application routing with role-based access expectations.

## Checklist

* Removed hardcoded dashboard redirects.
* Added role-aware navigation logic.
* Tested login flow with different user roles.
* Followed CONTRIBUTING.md guidelines.
