### PR TITLE
docs: fix broken back-to-top anchor link to match updated project title

### DIFF
--- a/ReadMe.md
+++ b/ReadMe.md
@@ -728,6 +728,6 @@ When reporting bugs, please include:
 
 **Made with ❤️ for Indian Restaurants**
 
-[⬆ Back to top](#-restrohub---digital-menu--restaurant-management-platform)
+[⬆ Back to top](#-restroly---digital-menu--restaurant-management-platform)
 
 </div>


### PR DESCRIPTION
## Summary

##Closes #266

Fixed a broken anchor link for the "Back to top" navigation at the bottom of the `README.md`.

**Why it is needed:** The primary H1 title of the document was updated to **Restroly**, but the anchor link at the bottom of the page was still targeting the old **RestroHub** heading format (`#-restrohub---digital-menu...`). Because the target no longer existed, clicking the link did nothing. Updating the anchor to match the current `Restroly` title restores the expected navigation functionality.

## Testing

Verified that clicking the link correctly routes the user back to the top of the document in standard Markdown previewers.

## Checklist

- [x] I have tested the change locally.
- [x] I have updated documentation if needed.