### PR TITLE
fix: eliminate N+1 queries when fetching subscription plans with feat…

### DIFF
--- a/RestroHub/src/main/java/com/restroly/qrmenu/subscription/repository/SubscriptionPlanRepository.java
+++ b/RestroHub/src/main/java/com/restroly/qrmenu/subscription/repository/SubscriptionPlanRepository.java
@@ -2,11 +2,25 @@ package com.restroly.qrmenu.subscription.repository;
 
 import com.restroly.qrmenu.subscription.entity.SubscriptionPlan;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
 import java.util.Optional;
 
 @Repository
 public interface SubscriptionPlanRepository extends JpaRepository<SubscriptionPlan, Long> {
     Optional<SubscriptionPlan> findByName(String name);
+
+    @Query("SELECT DISTINCT p FROM SubscriptionPlan p " +
+           "LEFT JOIN FETCH p.features f " +
+           "LEFT JOIN FETCH f.feature")
+    List<SubscriptionPlan> findAllWithFeatures();
+
+    @Query("SELECT DISTINCT p FROM SubscriptionPlan p " +
+           "LEFT JOIN FETCH p.features f " +
+           "LEFT JOIN FETCH f.feature " +
+           "WHERE p.id = :planId")
+    Optional<SubscriptionPlan> findByIdWithFeatures(@Param("planId") Long planId);
 }

--- a/RestroHub/src/main/java/com/restroly/qrmenu/subscription/service/impl/SubscriptionServiceImpl.java
+++ b/RestroHub/src/main/java/com/restroly/qrmenu/subscription/service/impl/SubscriptionServiceImpl.java
@@ -102,14 +102,14 @@ public class SubscriptionServiceImpl implements SubscriptionService {
 
     @Override
     public List<SubscriptionPlanDto> getAllPlans() {
-        return planRepository.findAll().stream()
+        return planRepository.findAllWithFeatures().stream()
                 .map(this::mapToDto)
                 .collect(Collectors.toList());
     }
 
     @Override
     public SubscriptionPlanDto getPlanById(Long planId) {
-        return planRepository.findById(planId)
+        return planRepository.findByIdWithFeatures(planId)
                 .map(this::mapToDto)
                 .orElseThrow(() -> new RuntimeException("Plan not found with id: " + planId));
     }


### PR DESCRIPTION
## Summary
Fixes the N+1 query problem when fetching subscription plans and their features.

- Added `findAllWithFeatures()` and `findByIdWithFeatures()` with `LEFT JOIN FETCH`
- Updated `getAllPlans()` and `getPlanById()` to use the eager-fetch queries

Closes #272

