### PR TITLE
feat(category): add restore endpoint for soft-deleted categories

### DIFF
--- a/RestroHub/src/main/java/com/restroly/qrmenu/category/controller/CategoryController.java
+++ b/RestroHub/src/main/java/com/restroly/qrmenu/category/controller/CategoryController.java
@@ -59,6 +59,12 @@ public class CategoryController {
 		return ResponseEntity.ok(ApiResponse.success(null, "Category deleted (soft-deleted) successfully"));
 	}
 
+	@PutMapping("/restore/{id}")
+	public ResponseEntity<ApiResponse<CategoryResponseDTO>> restoreCategory(@PathVariable Long id) {
+		CategoryResponseDTO restored = categoryService.restoreCategory(id);
+		return ResponseEntity.ok(ApiResponse.success(restored, "Category restored successfully"));
+	}
+
 	@GetMapping("/activecategories")
 	public ResponseEntity<ApiResponse<PagedResponse<CategoryResponseDTO>>> getActiveCategories(
 			@PageableDefault(page = 0, size = 10, sort = "name") Pageable pageable) {

--- a/RestroHub/src/main/java/com/restroly/qrmenu/category/service/CategoryService.java
+++ b/RestroHub/src/main/java/com/restroly/qrmenu/category/service/CategoryService.java
@@ -18,6 +18,8 @@ public interface CategoryService {
 
 	public void deleteCategory(Long id);
 
+	public CategoryResponseDTO restoreCategory(Long id);
+
 	public Page<CategoryResponseDTO> getActiveCategories(Pageable pageable);
 
 }

--- a/RestroHub/src/main/java/com/restroly/qrmenu/category/service/CategoryServiceImpl.java
+++ b/RestroHub/src/main/java/com/restroly/qrmenu/category/service/CategoryServiceImpl.java
@@ -110,6 +110,29 @@ public class CategoryServiceImpl implements CategoryService {
 		categoryRepository.save(existingCategory);
 	}
 
+	/* =======================
+       RESTORE SOFT-DELETED CATEGORY
+     ======================= */
+	@Override
+	@Transactional
+	public CategoryResponseDTO restoreCategory(Long id) {
+		log.debug("Restoring category with ID: {}", id);
+		Category existingCategory = categoryRepository.findById(id)
+				.orElseThrow(() ->
+						new ResourceNotFoundException("Category", "id", id));
+
+		if (Boolean.FALSE.equals(existingCategory.getIsDelete())) {
+			log.warn("Category with ID: {} is already active", id);
+			return CategoryResponseDTO.fromEntity(existingCategory);
+		}
+
+		existingCategory.setIsDelete(false);
+		existingCategory.setUpdatedDate(LocalDateTime.now());
+		Category restored = categoryRepository.save(existingCategory);
+		log.info("Category with ID: {} restored successfully", id);
+		return CategoryResponseDTO.fromEntity(restored);
+	}
+
 	@Override
 	@Transactional(readOnly = true)
 	public Page<CategoryResponseDTO> getActiveCategories(Pageable pageable) {


### PR DESCRIPTION
## Summary
Mirrors menu/branch restore behavior so admins can recover accidentally deleted categories via PUT /restore/{id}.

Closes #206