### PR TITLE
[FIX] Add error feedback and toast notification to CategoryFormModal

### DIFF
--- a/RestroHub-FrontEnd/src/components/admin/menu/menuCard/CategoryFormModal.jsx
+++ b/RestroHub-FrontEnd/src/components/admin/menu/menuCard/CategoryFormModal.jsx
@@ -1,7 +1,8 @@
 import { useState } from "react";
 import { Dialog } from "@headlessui/react";
-import { X, Loader2, Tag, Type, FileText  } from "lucide-react";
+import { X, Loader2, Tag, Type, FileText, AlertCircle } from "lucide-react";
 import api from "@services/common/api";
+import toast from "react-hot-toast";
 
 const CategoryFormModal = ({ isOpen, onClose }) => {
   const [formData, setFormData] = useState({
@@ -10,18 +11,21 @@ const CategoryFormModal = ({ isOpen, onClose }) => {
   });
 
   const [submitting, setSubmitting] = useState(false);
+  const [submitError, setSubmitError] = useState("");
 
   const updateField = (field, value) => {
     setFormData(prev => ({
       ...prev,
       [field]: value
     }));
+    setSubmitError("");
   };
 
   const handleSubmit = async (e) => {
     e.preventDefault();
     try {
       setSubmitting(true);
+      setSubmitError("");
 
       const payload = {
         name: formData.name,
@@ -31,11 +35,14 @@ const CategoryFormModal = ({ isOpen, onClose }) => {
 
       await api.post("/secure/api/v1/categories/addCategory", payload);
 
+      toast.success("Category created successfully");
       onClose();
       setFormData({ name: "", description: "" });
 
     } catch (err) {
-      console.error("Category create failed:", err.response?.data || err);
+      const message = err.response?.data?.message || err.message || "Failed to create category";
+      setSubmitError(message);
+      toast.error(message);
     } finally {
       setSubmitting(false);
     }
@@ -72,6 +79,14 @@ const CategoryFormModal = ({ isOpen, onClose }) => {
 
         {/* ========== FORM BODY ========== */}
         <form onSubmit={handleSubmit} className="px-6 py-6 space-y-5">
+
+          {/* Error Banner */}
+          {submitError && (
+            <div className="flex items-start gap-3 p-4 bg-red-50 border border-red-200 rounded-xl">
+              <AlertCircle className="w-5 h-5 text-red-500 shrink-0 mt-0.5" />
+              <p className="text-sm text-red-700">{submitError}</p>
+            </div>
+          )}
 
           {/* Category Name */}
           <div className="space-y-1.5">

--- a/RestroHub-FrontEnd/src/components/admin/menu/menuCard/CategoryFormModal.jsx
+++ b/RestroHub-FrontEnd/src/components/admin/menu/menuCard/CategoryFormModal.jsx
@@ -82,8 +82,12 @@ const CategoryFormModal = ({ isOpen, onClose }) => {
 
           {/* Error Banner */}
           {submitError && (
-            <div className="flex items-start gap-3 p-4 bg-red-50 border border-red-200 rounded-xl">
-              <AlertCircle className="w-5 h-5 text-red-500 shrink-0 mt-0.5" />
+            <div
+              role="alert"
+              aria-live="polite"
+              className="flex items-start gap-3 p-4 bg-red-50 border border-red-200 rounded-xl"
+            >
+              <AlertCircle aria-hidden="true" className="w-5 h-5 text-red-500 shrink-0 mt-0.5" />
               <p className="text-sm text-red-700">{submitError}</p>
             </div>
           )}


### PR DESCRIPTION
## Description

Added user-facing error feedback to the category creation modal. Previously, API errors were silently swallowed with only a `console.error` call.

## Changes Made

- Added `submitError` state variable to track API error messages
- Added inline error banner with `AlertCircle` icon that appears on failure
- Added `toast.success()` on successful category creation
- Added `toast.error()` with the API error message on failure
- Error clears automatically when the user edits any field
- Imported `AlertCircle` from lucide-react and `toast` from react-hot-toast

## Testing

1. Open Add Category modal
2. Submit with valid data → toast.success shown, modal closes
3. Force API error (e.g., network disconnect) → inline error banner + toast.error shown
4. Edit a field → error clears automatically

Fixes #283